### PR TITLE
fix: add missing AM_CONDITIONAL for UNSAFE_RESTORE_WARNINGS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+acl (2.3.2-2deepin4) unstable; urgency=medium
+
+  * Fix incomplete function rename from CVE-2026-54369.patch:
+    - Add missing libacl/__acl_apply_mask_to_mode.c source file (renamed
+      from __apply_mask_to_mode.c)
+    - Fix remaining __apply_mask_to_mode call in libacl/perm_copy_file.c
+    - Without these fixes the build fails with "No rule to make target
+      libacl/__acl_apply_mask_to_mode.c"
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 08 Jul 2026 15:07:28 +0800
+
+acl (2.3.2-2deepin3) unstable; urgency=medium
+
+  * Fix missing AM_CONDITIONAL for UNSAFE_RESTORE_WARNINGS
+    - Add AM_CONDITIONAL([UNSAFE_RESTORE_WARNINGS], [false]) to configure.ac
+    - Required by automake >= 1.16.1 when CVE-2026-54370.patch adds
+      conditional test blocks in test/Makemodule.am
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 08 Jul 2026 14:46:10 +0800
+
 acl (2.3.2-2deepin2) unstable; urgency=medium
 
   * Fix CVE-2026-54369: symlink traversal in libacl pathname-based functions

--- a/debian/patches/fix-missing-acl-apply-mask-to-mode-source.patch
+++ b/debian/patches/fix-missing-acl-apply-mask-to-mode-source.patch
@@ -1,0 +1,169 @@
+Description: Add missing __acl_apply_mask_to_mode.c and fix remaining references
+  The CVE-2026-54369.patch renamed __apply_mask_to_mode to
+  __acl_apply_mask_to_mode in libacl.h and perm_copy_fd.c and updated
+  the file reference in libacl/Makemodule.am, but:
+  1. Never created the new source file __acl_apply_mask_to_mode.c
+  2. Missed updating the call site in perm_copy_file.c:192
+  This patch fixes both issues: creates the new source file, removes
+  the old file, and updates the remaining call site.
+Forwarded: not-needed
+Last-Update: 2026-07-08
+---
+
+diff --git a/libacl/__apply_mask_to_mode.c b/libacl/__apply_mask_to_mode.c
+deleted file mode 100644
+--- a/libacl/__apply_mask_to_mode.c
++++ /dev/null
+@@ -1,67 +0,0 @@
+-/*
+-  File: __apply_mask_to_mode.c
+-  (Linux Access Control List Management)
+-
+-  Copyright (C) 1999-2002
+-  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, see <https://www.gnu.org/licenses/>.
+-*/
+-
+-#include "config.h"
+-#include <sys/stat.h>
+-#include "libacl.h"
+-
+-#if defined(HAVE_ACL_ENTRIES) && \
+-    defined (HAVE_ACL_GET_ENTRY) && defined(HAVE_ACL_GET_TAG_TYPE) && \
+-    defined (HAVE_ACL_GET_PERMSET) && defined(HAVE_ACL_GET_PERM)
+-int
+-__apply_mask_to_mode(mode_t *mode, acl_t acl)
+-{
+-	acl_entry_t entry;
+-	int entry_id=ACL_FIRST_ENTRY;
+-
+-	/* A minimal ACL which has three entries has no mask entry; the
+-	   group file mode permission bits are exact. */
+-	if (acl_entries(acl) == 3)
+-		return 0;
+-
+-	while (acl_get_entry(acl, entry_id, &entry) == 1) {
+-		acl_tag_t tag_type;
+-
+-		acl_get_tag_type(entry, &tag_type);
+-		if (tag_type == ACL_MASK) {
+-			acl_permset_t permset;
+-
+-			acl_get_permset(entry, &permset);
+-			if (acl_get_perm(permset, ACL_READ) != 1)
+-				*mode &= ~S_IRGRP;
+-			if (acl_get_perm(permset, ACL_WRITE) != 1)
+-				*mode &= ~S_IWGRP;
+-			if (acl_get_perm(permset, ACL_EXECUTE) != 1)
+-				*mode &= ~S_IXGRP;
+-
+-			return 0;
+-		}
+-		entry_id = ACL_NEXT_ENTRY;
+-	}
+-
+-	/* This is unexpected; if the ACL didn't include a mask entry
+-	   we should have exited before the loop! */
+-	*mode &= ~S_IRWXG;
+-	return 1;
+-}
+-#endif
+-
+-
+diff --git a/libacl/perm_copy_file.c b/libacl/perm_copy_file.c
+--- a/libacl/perm_copy_file.c
++++ b/libacl/perm_copy_file.c
+@@ -189,7 +189,7 @@ perm_copy_file (const char *src_path, const char *dst_path,
+ 
+ 	if (acl_set_file (dst_path, ACL_TYPE_ACCESS, acl) != 0) {
+ 		int saved_errno = errno;
+-		__apply_mask_to_mode(&st.st_mode, acl);
++		__acl_apply_mask_to_mode(&st.st_mode, acl);
+ 		ret = chmod (dst_path, st.st_mode);
+ 		if ((errno != ENOSYS && errno != ENOTSUP) ||
+ 		    acl_entries (acl) != 3) {
+
+diff --git a/libacl/__acl_apply_mask_to_mode.c b/libacl/__acl_apply_mask_to_mode.c
+new file mode 100644
+--- /dev/null
++++ b/libacl/__acl_apply_mask_to_mode.c
+@@ -0,0 +1,67 @@
++/*
++  File: __acl_apply_mask_to_mode.c
++  (Linux Access Control List Management)
++
++  Copyright (C) 1999-2002
++  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/stat.h>
++#include "libacl.h"
++
++#if defined(HAVE_ACL_ENTRIES) && \
++    defined (HAVE_ACL_GET_ENTRY) && defined(HAVE_ACL_GET_TAG_TYPE) && \
++    defined (HAVE_ACL_GET_PERMSET) && defined(HAVE_ACL_GET_PERM)
++int
++__acl_apply_mask_to_mode(mode_t *mode, acl_t acl)
++{
++	acl_entry_t entry;
++	int entry_id=ACL_FIRST_ENTRY;
++
++	/* A minimal ACL which has three entries has no mask entry; the
++	   group file mode permission bits are exact. */
++	if (acl_entries(acl) == 3)
++		return 0;
++
++	while (acl_get_entry(acl, entry_id, &entry) == 1) {
++		acl_tag_t tag_type;
++
++		acl_get_tag_type(entry, &tag_type);
++		if (tag_type == ACL_MASK) {
++			acl_permset_t permset;
++
++			acl_get_permset(entry, &permset);
++			if (acl_get_perm(permset, ACL_READ) != 1)
++				*mode &= ~S_IRGRP;
++			if (acl_get_perm(permset, ACL_WRITE) != 1)
++				*mode &= ~S_IWGRP;
++			if (acl_get_perm(permset, ACL_EXECUTE) != 1)
++				*mode &= ~S_IXGRP;
++
++			return 0;
++		}
++		entry_id = ACL_NEXT_ENTRY;
++	}
++
++	/* This is unexpected; if the ACL didn't include a mask entry
++	   we should have exited before the loop! */
++	*mode &= ~S_IRWXG;
++	return 1;
++}
++#endif
++
++

--- a/debian/patches/fix-unsave-restore-warnings-conditional.patch
+++ b/debian/patches/fix-unsave-restore-warnings-conditional.patch
@@ -1,0 +1,17 @@
+Description: Declare UNSAFE_RESTORE_WARNINGS conditional for automake >= 1.16.1
+  The CVE-2026-54370.patch adds a conditional block in test/Makemodule.am
+  referencing UNSAFE_RESTORE_WARNINGS. Newer automake versions (>= 1.16.1)
+  require all Makefile.am conditionals to be declared via AM_CONDITIONAL
+  in configure.ac. This patch adds the missing declaration.
+Forwarded: not-needed
+Last-Update: 2026-07-08
+---
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,4 +71,5 @@
+ 	Makefile
+ 	po/Makefile.in
+ ])
++AM_CONDITIONAL([UNSAFE_RESTORE_WARNINGS], [false])
+ AC_OUTPUT

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,8 @@ getfacl-fix-uninitialized-variable.patch
 CVE-2026-54369.patch
 # CVE-2026-54370: TOCTOU hardening (getfacl, setfacl, chacl)
 CVE-2026-54370.patch
+# Fix missing AM_CONDITIONAL for UNSAFE_RESTORE_WARNINGS (needed by CVE-2026-54370.patch)
+fix-unsave-restore-warnings-conditional.patch
+# Fix missing __acl_apply_mask_to_mode.c source file (CVE-2026-54369.patch renamed
+# __apply_mask_to_mode to __acl_apply_mask_to_mode but forgot the source file)
+fix-missing-acl-apply-mask-to-mode-source.patch


### PR DESCRIPTION
The CVE-2026-54370.patch introduces a conditional block "if UNSAFE_RESTORE_WARNINGS" in test/Makemodule.am, but configure.ac never declares this conditional via AM_CONDITIONAL. Automake >= 1.16.1 enforces that all Makefile.am conditionals must be pre-declared, causing the build to fail with:
  test/Makemodule.am:20: error: UNSAFE_RESTORE_WARNINGS
  does not appear in AM_CONDITIONAL
Add AM_CONDITIONAL([UNSAFE_RESTORE_WARNINGS], [false]) before AC_OUTPUT to satisfy the automake requirement.

Log: Fix automake build failure by declaring UNSAFE_RESTORE_WARNINGS conditional

Influence:
1. Verify pbuilder/quilt build succeeds with automake 1.17
2. Confirm CVE-2026-54370.patch still applies cleanly
3. Test acl package builds on all supported architectures (amd64, arm64, loong64, sw64, riscv)
4. Verify no regression in acl test suite

fix: 添加缺失的 UNSAFE_RESTORE_WARNINGS AM_CONDITIONAL 声明

CVE-2026-54370.patch 在 test/Makemodule.am 中引入了条件块
"if UNSAFE_RESTORE_WARNINGS"，但 configure.ac 中未通过
AM_CONDITIONAL 声明该条件。Automake >= 1.16.1 强制要求所有
Makefile.am 中的条件必须预先声明，导致构建报上述错误。
在 AC_OUTPUT 之前添加 AM_CONDITIONAL([UNSAFE_RESTORE_WARNINGS], [false]) 以满足 automake 要求。

Log: 通过声明 UNSAFE_RESTORE_WARNINGS 条件修复 automake 构建失败

Influence:
1. 验证 pbuilder/quilt 构建在 automake 1.17 下成功
2. 确认 CVE-2026-54370.patch 仍然干净应用
3. 测试 acl 包在所有支持架构上构建正常（amd64, arm64, loong64, sw64, riscv）
4. 验证 acl 测试套件无回归

repo: acl #master