### PR TITLE
fix(acl): CVE-2026-54369, CVE-2026-54370 symlink traversal and TOCTOU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+acl (2.3.2-2deepin2) unstable; urgency=medium
+
+  * Fix CVE-2026-54369: symlink traversal in libacl pathname-based functions
+    (acl_get_file, acl_set_file, acl_extended_file, acl_delete_def_file)
+    - Add walk_tree helper using directory file descriptors
+    - Add openat2 syscall wrapper for RESOLVE_NO_SYMLINKS
+    - Add xattrat/fchmodat syscall backwards compatibility code
+    - Add libacl _at function variants (acl_get_file_at, acl_set_file_at,
+      acl_extended_file_at, acl_delete_def_file_at)
+
+  * Fix CVE-2026-54370: TOCTOU race condition in getfacl, setfacl, chacl
+    - Harden getfacl: switch to symlink-safe functions (fstatat, acl_get_file_at)
+    - Harden setfacl: switch to symlink-safe functions (fstatat, fchmodat,
+      acl_set_file_at)
+    - Harden setfacl --restore: use openat2(RESOLVE_NO_SYMLINKS)
+    - Harden chacl: use directory file descriptors and AT_SYMLINK_NOFOLLOW
+
+  * Fix compiler warnings for CVE-2026-54369 and CVE-2026-54370
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 28 Jul 2026 16:17:23 +0800
+
 acl (2.3.2-2deepin1) unstable; urgency=medium
 
   * Add sw64 architecture support for test suite

--- a/debian/patches/backport-0001-CVE-2026-54369.patch
+++ b/debian/patches/backport-0001-CVE-2026-54369.patch
@@ -1,0 +1,60 @@
+From 60d3c0c7539f4082ab963c9b20a8fa3ac0fbc73e Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Fri, 12 Jun 2026 16:56:37 +0200
+Subject: [PATCH] Split off visibility attribute header
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ include/Makemodule.am       |  1 +
+ include/misc.h              |  8 +-------
+ include/visibility-hidden.h | 11 +++++++++++
+ 3 files changed, 13 insertions(+), 7 deletions(-)
+ create mode 100644 include/visibility-hidden.h
+
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -3,6 +3,7 @@ noinst_HEADERS += \
+ 	include/acl.h \
+ 	include/acl_ea.h \
+ 	include/misc.h \
++	include/visibility-hidden.h \
+ 	include/walk_tree.h
+ 
+ SUBST_INSTALL_HEADER = \
+Index: acl/include/misc.h
+===================================================================
+--- acl.orig/include/misc.h
++++ acl/include/misc.h
+@@ -20,13 +20,7 @@
+ 
+ #include <stdio.h>
+ #include <sys/types.h>
+-
+-/* Mark library internal functions as hidden */
+-#if defined(HAVE_VISIBILITY_ATTRIBUTE)
+-# define hidden __attribute__((visibility("hidden")))
+-#else
+-# define hidden /* hidden */
+-#endif
++#include "include/visibility-hidden.h"
+ 
+ hidden int __acl_high_water_alloc(void **buf, size_t *bufsize, size_t newsize);
+ 
+Index: acl/include/visibility-hidden.h
+===================================================================
+--- /dev/null
++++ acl/include/visibility-hidden.h
+@@ -0,0 +1,11 @@
++#ifndef VISIBILITY_HIDDEN_H
++#define VISIBILITY_HIDDEN_H
++
++/* Mark library internal functions as hidden */
++#if defined(HAVE_VISIBILITY_ATTRIBUTE)
++# define hidden __attribute__((visibility("hidden")))
++#else
++# define hidden /* hidden */
++#endif
++
++#endif /* VISIBILITY_HIDDEN_H */

--- a/debian/patches/backport-0001-CVE-2026-54370.patch
+++ b/debian/patches/backport-0001-CVE-2026-54370.patch
@@ -1,0 +1,44 @@
+From 8f997cee2c5c2a494069af3b3ce1151a966b4509 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Wed, 31 Jan 2024 23:46:07 -0500
+Subject: [PATCH] tools: move do_set externs to common header
+
+This helps enforce the types that do_set.c expects are what modules
+that include do_set.h actually export.
+
+Also trim unused print_options since do_set doesn't use it.
+---
+ tools/do_set.c | 5 -----
+ tools/do_set.h | 5 +++++
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+Index: acl/tools/do_set.c
+===================================================================
+--- acl.orig/tools/do_set.c
++++ acl/tools/do_set.c
+@@ -40,11 +40,6 @@
+ #include "walk_tree.h"
+ 
+ 
+-extern const char *progname;
+-extern int opt_recalculate;
+-extern int opt_test;
+-extern int print_options;
+-
+ acl_entry_t
+ find_entry(
+ 	acl_t acl,
+Index: acl/tools/do_set.h
+===================================================================
+--- acl.orig/tools/do_set.h
++++ acl/tools/do_set.h
+@@ -32,4 +32,9 @@ struct do_set_args {
+ extern int do_set(const char *path_p, const struct stat *stat_p, int flags,
+ 		  void *arg);
+ 
++/* We need these exported to us. */
++extern const char *progname;
++extern int opt_recalculate;
++extern int opt_test;
++
+ #endif  /* __DO_SET_H */

--- a/debian/patches/backport-0002-CVE-2026-54369.patch
+++ b/debian/patches/backport-0002-CVE-2026-54369.patch
@@ -1,0 +1,184 @@
+From 4eb92d4d449d16fdae4f9ba332809ff9bfd47e65 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Fri, 12 Jun 2026 13:18:23 +0200
+Subject: [PATCH] Add xattrat syscall wrappers
+
+The getxattrat(), setxattrat(), listxattrat(), and removexattrat() system calls
+don't have shims provided by glibc, yet.  For each of those system calls, test
+if glibc defines it and add a local shim using syscall() if not.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ configure.ac          |  7 ++++
+ include/Makemodule.am |  3 +-
+ include/xattrat.h     | 25 +++++++++++++
+ libmisc/Makemodule.am |  5 +++
+ libmisc/xattrat.c     | 84 +++++++++++++++++++++++++++++++++++++++++++
+ 5 files changed, 123 insertions(+), 1 deletion(-)
+ create mode 100644 include/xattrat.h
+ create mode 100644 libmisc/xattrat.c
+
+Index: acl/configure.ac
+===================================================================
+--- acl.orig/configure.ac
++++ acl/configure.ac
+@@ -34,6 +34,13 @@ AC_SYS_LARGEFILE
+ AM_PROG_AR
+ LT_INIT
+ 
++AC_CHECK_FUNCS(getxattrat setxattrat listxattrat removexattrat)
++AM_CONDITIONAL([NEED_XATTRAT],
++	       [test "x$ac_cv_func_getxattrat" = xno -o \
++		     "x$ac_cv_func_setxattrat" = xno -o \
++		     "x$ac_cv_func_listxattrat" = xno -o \
++		     "x$ac_cv_func_removexattrat" = xno])
++
+ dnl Minimal version supporting AM_GNU_GETTEXT_REQUIRE_VERSION.
+ AM_GNU_GETTEXT_VERSION([0.19.6])
+ dnl Require at least the following version, but use the latest available one.
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -4,7 +4,8 @@ noinst_HEADERS += \
+ 	include/acl_ea.h \
+ 	include/misc.h \
+ 	include/visibility-hidden.h \
+-	include/walk_tree.h
++	include/walk_tree.h \
++	include/xattrat.h
+ 
+ SUBST_INSTALL_HEADER = \
+ 	subst_install_header() { \
+Index: acl/include/xattrat.h
+===================================================================
+--- /dev/null
++++ acl/include/xattrat.h
+@@ -0,0 +1,25 @@
++#ifndef MISC_XATTRAT_H
++#define MISC_XATTRAT_H
++
++#include "config.h"
++
++#ifndef HAVE_GETXATTRAT
++ssize_t getxattrat(int dirfd, const char *path, int at_flags, const char *name,
++		   void *value, size_t size);
++#endif
++
++#ifndef HAVE_SETXATTRAT
++int setxattrat(int dirfd, const char *path, int at_flags, const char *name,
++	       const void *value, size_t size, int flags);
++#endif
++
++#ifndef HAVE_LISTXATTRAT
++ssize_t listxattrat(int dirfd, const char *path, int at_flags, char *list,
++		    size_t size);
++#endif
++
++#ifndef HAVE_REMOVEXATTRAT
++int removexattrat(int dirfd, const char *path, int at_flags, const char *name);
++#endif
++
++#endif /* MISC_XATTRAT_H */
+Index: acl/libmisc/Makemodule.am
+===================================================================
+--- acl.orig/libmisc/Makemodule.am
++++ acl/libmisc/Makemodule.am
+@@ -7,3 +7,8 @@ libmisc_la_SOURCES = \
+ 	libmisc/quote.c \
+ 	libmisc/unquote.c \
+ 	libmisc/walk_tree.c
++
++if NEED_XATTRAT
++libmisc_la_SOURCES += \
++	libmisc/xattrat.c
++endif
+Index: acl/libmisc/xattrat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/xattrat.c
+@@ -0,0 +1,84 @@
++/*
++  File: xattrat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <linux/xattr.h>
++#include <sys/syscall.h>
++#include <unistd.h>
++
++#include "xattrat.h"
++
++ssize_t
++getxattrat(int dirfd, const char *path, int at_flags, const char *name,
++	   void *value, size_t size)
++{
++#ifdef __NR_getxattrat
++	struct xattr_args uargs = {
++		.value = (unsigned long)value,
++		.size = size,
++	};
++
++	return syscall(__NR_getxattrat, dirfd, path, at_flags, name,
++		       &uargs, sizeof(uargs));
++#else
++	errno = ENOSYS;
++	return -1;
++#endif
++}
++
++int
++setxattrat(int dirfd, const char *path, int at_flags, const char *name,
++	   const void *value, size_t size, int flags)
++{
++#ifdef __NR_setxattrat
++	struct xattr_args uargs = {
++		.value = (unsigned long)value,
++		.size = size,
++		.flags = flags,
++	};
++
++        return syscall(__NR_setxattrat, dirfd, path, at_flags, name,
++                       &uargs, sizeof(uargs));
++#else
++	errno = ENOSYS;
++	return -1;
++#endif
++}
++
++ssize_t listxattrat(int dirfd, const char *path, int at_flags, char *list,
++		    size_t size)
++{
++#ifdef __NR_listxattrat
++        return syscall(__NR_listxattrat, dirfd, path, at_flags, list, size);
++#else
++	errno = ENOSYS;
++	return -1;
++#endif
++}
++
++int
++removexattrat(int dirfd, const char *path, int at_flags, const char *name)
++{
++#ifdef __NR_removexattrat
++	return syscall(__NR_removexattrat, dirfd, path, at_flags, name);
++#else
++	errno = ENOSYS;
++	return -1;
++#endif
++}

--- a/debian/patches/backport-0002-CVE-2026-54370.patch
+++ b/debian/patches/backport-0002-CVE-2026-54370.patch
@@ -1,0 +1,272 @@
+From 339ff0c5d46d6f5e5113415995c6a60bfc4b1928 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Wed, 31 Jan 2024 23:47:50 -0500
+Subject: [PATCH] tools: mark local vars & funcs static
+
+These programs have a lot of local vars & funcs that don't need to
+be exported.  Mark them static to cleanup, and the compiler is able
+to produce smaller code as a result -- about ~3% .text on x86_64.
+---
+ tools/do_set.c  |  8 ++++----
+ tools/getfacl.c | 54 ++++++++++++++++++++++++-------------------------
+ tools/setfacl.c | 22 ++++++++++----------
+ 3 files changed, 42 insertions(+), 42 deletions(-)
+
+Index: acl/tools/do_set.c
+===================================================================
+--- acl.orig/tools/do_set.c
++++ acl/tools/do_set.c
+@@ -40,7 +40,7 @@
+ #include "walk_tree.h"
+ 
+ 
+-acl_entry_t
++static acl_entry_t
+ find_entry(
+ 	acl_t acl,
+ 	acl_tag_t type,
+@@ -74,7 +74,7 @@ find_entry(
+ 	}
+ }
+ 
+-int
++static int
+ has_execute_perms(
+ 	acl_t acl)
+ {
+@@ -95,7 +95,7 @@ has_execute_perms(
+ 	}
+ }
+ 
+-int
++static int
+ clone_entry(
+ 	acl_t from_acl,
+ 	acl_tag_t from_type,
+@@ -116,7 +116,7 @@ clone_entry(
+ }
+ 
+ 
+-void
++static void
+ print_test(
+ 	FILE *file,
+ 	const char *path_p,
+Index: acl/tools/getfacl.c
+===================================================================
+--- acl.orig/tools/getfacl.c
++++ acl/tools/getfacl.c
+@@ -68,24 +68,24 @@ static const struct option long_options[
+ };
+ 
+ const char *progname;
+-const char *cmd_line_options;
++static const char *cmd_line_options;
+ 
+-int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
+-int opt_print_acl;
+-int opt_print_default_acl;
+-int opt_strip_leading_slash = 1;
+-int opt_comments = 1;  /* include comments */
+-int opt_skip_base;  /* skip files that only have the base entries */
+-int opt_tabular;  /* tabular output format (alias `showacl') */
++static int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
++static int opt_print_acl;
++static int opt_print_default_acl;
++static int opt_strip_leading_slash = 1;
++static int opt_comments = 1;  /* include comments */
++static int opt_skip_base;  /* skip files that only have the base entries */
++static int opt_tabular;  /* tabular output format (alias `showacl') */
+ #if POSIXLY_CORRECT
+-const int posixly_correct = 1;  /* Posix compatible behavior! */
++static const int posixly_correct = 1;  /* Posix compatible behavior! */
+ #else
+-int posixly_correct;  /* Posix compatible behavior? */
++static int posixly_correct;  /* Posix compatible behavior? */
+ #endif
+-int had_errors;
+-int absolute_warning;  /* Absolute path warning was issued */
+-int print_options = TEXT_SOME_EFFECTIVE;
+-int opt_numeric;  /* don't convert id's to symbolic names */
++static int had_errors;
++static int absolute_warning;  /* Absolute path warning was issued */
++static int print_options = TEXT_SOME_EFFECTIVE;
++static int opt_numeric;  /* don't convert id's to symbolic names */
+ 
+ 
+ static const char *xquote(const char *str, const char *quote_chars)
+@@ -103,7 +103,7 @@ struct name_list {
+ 	char name[0];
+ };
+ 
+-void free_list(struct name_list *names)
++static void free_list(struct name_list *names)
+ {
+ 	struct name_list *next;
+ 
+@@ -114,7 +114,7 @@ void free_list(struct name_list *names)
+ 	}
+ }
+ 
+-struct name_list *get_list(const struct stat *st, acl_t acl)
++static struct name_list *get_list(const struct stat *st, acl_t acl)
+ {
+ 	struct name_list *first = NULL, *last = NULL;
+ 	acl_entry_t ent;
+@@ -178,7 +178,7 @@ struct name_list *get_list(const struct
+ 	return first;
+ }
+ 
+-int max_name_length(struct name_list *names)
++static int max_name_length(struct name_list *names)
+ {
+ 	int max_len = 0;
+ 	while (names != NULL) {
+@@ -192,14 +192,14 @@ int max_name_length(struct name_list *na
+ 	return max_len;
+ }
+ 
+-int names_width;
++static int names_width;
+ 
+ struct acl_perm_def {
+ 	acl_tag_t	tag;
+ 	char		c;
+ };
+ 
+-struct acl_perm_def acl_perm_defs[] = {
++static const struct acl_perm_def acl_perm_defs[] = {
+ 	{ ACL_READ,	'r' },
+ 	{ ACL_WRITE,	'w' },
+ 	{ ACL_EXECUTE,	'x' },
+@@ -208,7 +208,7 @@ struct acl_perm_def acl_perm_defs[] = {
+ 
+ #define ACL_PERMS (sizeof(acl_perm_defs) / sizeof(struct acl_perm_def) - 1)
+ 
+-void acl_perm_str(acl_entry_t entry, char *str)
++static void acl_perm_str(acl_entry_t entry, char *str)
+ {
+ 	acl_permset_t permset;
+ 	int n;
+@@ -221,7 +221,7 @@ void acl_perm_str(acl_entry_t entry, cha
+ 	str[n] = '\0';
+ }
+ 
+-void acl_mask_perm_str(acl_t acl, char *str)
++static void acl_mask_perm_str(acl_t acl, char *str)
+ {
+ 	acl_entry_t entry;
+ 
+@@ -241,7 +241,7 @@ void acl_mask_perm_str(acl_t acl, char *
+ 	}
+ }
+ 
+-void apply_mask(char *perm, const char *mask)
++static void apply_mask(char *perm, const char *mask)
+ {
+ 	while (*perm) {
+ 		if (*mask == '-' && *perm >= 'a' && *perm <= 'z')
+@@ -252,7 +252,7 @@ void apply_mask(char *perm, const char *
+ 	}
+ }
+ 
+-int show_line(FILE *stream, struct name_list **acl_names,  acl_t acl,
++static int show_line(FILE *stream, struct name_list **acl_names,  acl_t acl,
+               acl_entry_t *acl_ent, const char *acl_mask,
+               struct name_list **dacl_names, acl_t dacl,
+ 	      acl_entry_t *dacl_ent, const char *dacl_mask)
+@@ -325,7 +325,7 @@ int show_line(FILE *stream, struct name_
+ 	return 0;
+ }
+ 
+-int do_show(FILE *stream, const char *path_p, const struct stat *st,
++static int do_show(FILE *stream, const char *path_p, const struct stat *st,
+             acl_t acl, acl_t dacl)
+ {
+ 	struct name_list *acl_names = get_list(st, acl),
+@@ -446,7 +446,7 @@ flagstr(mode_t mode)
+ 	return str;
+ }
+ 
+-int do_print(const char *path_p, const struct stat *st, int walk_flags, void *unused)
++static int do_print(const char *path_p, const struct stat *st, int walk_flags, void *unused)
+ {
+ 	const char *default_prefix = NULL;
+ 	acl_t acl = NULL, default_acl = NULL;
+@@ -566,7 +566,7 @@ fail:
+ }
+ 
+ 
+-void help(void)
++static void help(void)
+ {
+ 	printf(_("%s %s -- get file access control lists\n"),
+ 	       progname, VERSION);
+Index: acl/tools/setfacl.c
+===================================================================
+--- acl.orig/tools/setfacl.c
++++ acl/tools/setfacl.c
+@@ -72,20 +72,20 @@ static const struct option long_options[
+ };
+ 
+ const char *progname;
+-const char *cmd_line_options, *cmd_line_spec;
++static const char *cmd_line_options, *cmd_line_spec;
+ 
+-int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
++static int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
+ int opt_recalculate;  /* recalculate mask entry (0=default, 1=yes, -1=no) */
+-int opt_promote;  /* promote access ACL to default ACL */
++static int opt_promote;  /* promote access ACL to default ACL */
+ int opt_test;  /* do not write to the file system.
+                       Print what would happen instead. */
+ #if POSIXLY_CORRECT
+-const int posixly_correct = 1;  /* Posix compatible behavior! */
++static const int posixly_correct = 1;  /* Posix compatible behavior! */
+ #else
+-int posixly_correct;  /* Posix compatible behavior? */
++static int posixly_correct;  /* Posix compatible behavior? */
+ #endif
+-int chown_error;
+-int promote_warning;
++static int chown_error;
++static int promote_warning;
+ 
+ 
+ static const char *xquote(const char *str, const char *quote_chars)
+@@ -98,7 +98,7 @@ static const char *xquote(const char *st
+ 	return q;
+ }
+ 
+-int
++static int
+ has_any_of_type(
+ 	cmd_t cmd,
+ 	acl_type_t acl_type)
+@@ -113,7 +113,7 @@ has_any_of_type(
+ 	
+ 
+ #if !POSIXLY_CORRECT
+-int
++static int
+ restore(
+ 	FILE *file,
+ 	const char *filename)
+@@ -260,7 +260,7 @@ fail:
+ #endif
+ 
+ 
+-void help(void)
++static void help(void)
+ {
+ 	printf(_("%s %s -- set file access control lists\n"),
+ 		progname, VERSION);
+@@ -300,7 +300,7 @@ void help(void)
+ }
+ 
+ 
+-int next_file(const char *arg, seq_t seq)
++static int next_file(const char *arg, seq_t seq)
+ {
+ 	char *line;
+ 	int errors = 0;

--- a/debian/patches/backport-0003-CVE-2026-54369.patch
+++ b/debian/patches/backport-0003-CVE-2026-54369.patch
@@ -1,0 +1,674 @@
+From ea0b56cdd9b3d537da2366dacbbfc93fefce152a Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Fri, 12 Jun 2026 15:45:25 +0200
+Subject: [PATCH] Add xattrat syscall backwards compatibility code
+
+The getxattrat(), setxattrat(), listxattrat(), and removexattrat() system calls
+have only been added in kernel version 6.13 which was released in January 2025.
+On older systems, those system calls will fail with errno == ENOSYS.  So we use
+the old system calls (for example, getxattr() and lgetxattr()) when they are
+sufficient, and the new xattrat() system calls when they are needed.
+
+In addition, when the new system calls are not available, we resort to the
+following hacks for achieving the desired behavior: when dirfd is not AT_FDCWD,
+the pathname can usually be resolved relative to dirfd as
+"/proc/self/fd/<dirfd>/pathname".  And when that also fails because the
+resulting pathname is too long, the original pathname can be resolved using
+openat(dirfd, pathname, O_PATH) and then accessed as "/proc/self/fd/<fd>".
+
+Also, due to a current kernel limitation, the xattrat system calls will not
+accept dirfd file descriptors of type O_PATH with an empty pathname (and with
+the AT_EMPTY_PATH flag set in at_flags) [*].  When running into this case, we
+also fall back to accessing the file via "/proc/self/fd/<fd>".
+
+When those hacks fail because the /proc filesystem is not available, these
+compatibility wrappers will fail with errno == ENOSYS.
+
+[*] https://lore.kernel.org/linux-fsdevel/20260607164136.2948550-2-agruenba@redhat.com/
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ include/Makemodule.am          |   3 +-
+ include/xattrat_compat.h       |  24 ++++++++
+ libmisc/Makemodule.am          |   8 +++
+ libmisc/getxattrat_compat.c    | 108 +++++++++++++++++++++++++++++++++
+ libmisc/listxattrat_compat.c   | 107 ++++++++++++++++++++++++++++++++
+ libmisc/proc-self-fd.c         |  92 ++++++++++++++++++++++++++++
+ libmisc/proc-self-fd.h         |  31 ++++++++++
+ libmisc/removexattrat_compat.c | 107 ++++++++++++++++++++++++++++++++
+ libmisc/setxattrat_compat.c    | 108 +++++++++++++++++++++++++++++++++
+ 9 files changed, 587 insertions(+), 1 deletion(-)
+ create mode 100644 include/xattrat_compat.h
+ create mode 100644 libmisc/getxattrat_compat.c
+ create mode 100644 libmisc/listxattrat_compat.c
+ create mode 100644 libmisc/proc-self-fd.c
+ create mode 100644 libmisc/proc-self-fd.h
+ create mode 100644 libmisc/removexattrat_compat.c
+ create mode 100644 libmisc/setxattrat_compat.c
+
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -5,7 +5,8 @@ noinst_HEADERS += \
+ 	include/misc.h \
+ 	include/visibility-hidden.h \
+ 	include/walk_tree.h \
+-	include/xattrat.h
++	include/xattrat.h \
++	include/xattrat_compat.h
+ 
+ SUBST_INSTALL_HEADER = \
+ 	subst_install_header() { \
+Index: acl/include/xattrat_compat.h
+===================================================================
+--- /dev/null
++++ acl/include/xattrat_compat.h
+@@ -0,0 +1,24 @@
++#ifndef XATTRAT_COMPAT_H
++#define XATTRAT_COMPAT_H
++
++ssize_t getxattrat_compat(int dirfd, const char *path, int at_flags,
++			  const char *name, void *value, size_t size);
++
++int setxattrat_compat(int dirfd, const char *path, int at_flags,
++		      const char *name, const void *value, size_t size,
++		      int flags);
++
++ssize_t listxattrat_compat(int dirfd, const char *path, int at_flags,
++			   char *list, size_t size);
++
++int removexattrat_compat(int dirfd, const char *path, int at_flags,
++			 const char *name);
++
++#ifndef DECLARATIONS_ONLY
++# define getxattrat getxattrat_compat
++# define setxattrat setxattrat_compat
++# define listxattrat listxattrat_compat
++# define removexattrat removexattrat_compat
++#endif
++
++#endif /* XATTRAT_COMPAT_H */
+Index: acl/libmisc/getxattrat_compat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/getxattrat_compat.c
+@@ -0,0 +1,108 @@
++/*
++  File: getxattrat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/xattr.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <errno.h>
++#include <stdlib.h>
++#include "xattrat.h"
++#include "libmisc/proc-self-fd.h"
++
++#define DECLARATIONS_ONLY
++#include "xattrat_compat.h"
++
++/* Used in {set,list,remove}xattrat_compat.c */
++int slow_empty_paths;
++
++static ssize_t
++xgetxattr(const char *path, int at_flags, const char *name, void *value,
++	  size_t size)
++{
++	if (at_flags & AT_SYMLINK_NOFOLLOW)
++		return lgetxattr(path, name, value, size);
++	return getxattr(path, name, value, size);
++}
++
++ssize_t
++getxattrat_compat(int dirfd, const char *path, int at_flags, const char *name,
++		  void *value, size_t size)
++{
++	struct proc_self_fd_buffer buffer;
++	static int no_getxattrat;
++	char *newpath;
++	ssize_t ret;
++	int fd;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++	if (!*path) {
++		if (!(at_flags & AT_EMPTY_PATH)) {
++			errno = ENOENT;
++			return -1;
++		}
++	}
++
++	if (dirfd == AT_FDCWD || *path == '/')
++		return xgetxattr(path, at_flags, name, value, size);
++
++	if (!no_getxattrat) {
++		if (!*path && slow_empty_paths)
++			goto proc_self_fd_path;
++		ret = getxattrat(dirfd, path, at_flags, name, value, size);
++		if (ret != -1)
++		       return ret;
++		if (need_slow_empty_paths(dirfd, path)) {
++			slow_empty_paths = 1;
++			goto proc_self_fd_path;
++		}
++		if (errno != ENOSYS)
++			return -1;
++		no_getxattrat = 1;
++	}
++
++proc_self_fd_path:
++	newpath = proc_self_fd_realpath(dirfd, path, &at_flags, &buffer);
++	if (!newpath)
++		return -1;
++	ret = xgetxattr(newpath, at_flags, name, value, size);
++	proc_self_fd_free(newpath, &buffer);
++	if (ret != -1)
++		return ret;
++	if (errno == ENOENT) {
++		if (!*path) {
++			errno = EBADF;
++			return -1;
++		}
++		if (fcntl(dirfd, F_GETFL) != -1)
++			errno = ENOENT;
++		return -1;
++	} else if (errno != ENAMETOOLONG)
++		return ret;
++
++	fd = openat_with_flags(dirfd, path, at_flags);
++	if (fd == -1)
++		return -1;
++	ret = getxattr(proc_self_fd_path(fd, &buffer), name, value, size);
++	close(fd);
++	return ret;
++}
+Index: acl/libmisc/listxattrat_compat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/listxattrat_compat.c
+@@ -0,0 +1,107 @@
++/*
++  File: listxattrat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/xattr.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <errno.h>
++#include <stdlib.h>
++#include "xattrat.h"
++#include "libmisc/proc-self-fd.h"
++
++#define DECLARATIONS_ONLY
++#include "xattrat_compat.h"
++
++/* Defined in getxattrat_compat.c */
++extern int slow_empty_paths;
++
++static ssize_t
++xlistxattr(const char *path, int at_flags, char *list, size_t size)
++{
++	if (at_flags & AT_SYMLINK_NOFOLLOW)
++		return llistxattr(path, list, size);
++	return listxattr(path, list, size);
++}
++
++ssize_t
++listxattrat_compat(int dirfd, const char *path, int at_flags, char *list,
++		   size_t size)
++{
++	struct proc_self_fd_buffer buffer;
++	static int no_listxattrat;
++	char *newpath;
++	ssize_t ret;
++	int fd;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++	if (!*path) {
++		if (!(at_flags & AT_EMPTY_PATH)) {
++			errno = ENOENT;
++			return -1;
++		}
++	}
++
++	if (dirfd == AT_FDCWD || *path == '/')
++		return xlistxattr(path, at_flags, list, size);
++
++	if (!no_listxattrat) {
++		if (!*path && slow_empty_paths)
++			goto proc_self_fd_path;
++		ret = listxattrat(dirfd, path, at_flags, list, size);
++		if (ret != -1)
++		       return ret;
++		if (need_slow_empty_paths(dirfd, path)) {
++			slow_empty_paths = 1;
++			goto proc_self_fd_path;
++		}
++		if (errno != ENOSYS)
++			return -1;
++		no_listxattrat = 1;
++	}
++
++proc_self_fd_path:
++	newpath = proc_self_fd_realpath(dirfd, path, &at_flags, &buffer);
++	if (!newpath)
++		return -1;
++	ret = xlistxattr(newpath, at_flags, list, size);
++	proc_self_fd_free(newpath, &buffer);
++	if (ret != -1)
++		return ret;
++	if (errno == ENOENT) {
++		if (!*path) {
++			errno = EBADF;
++			return -1;
++		}
++		if (fcntl(dirfd, F_GETFL) != -1)
++			errno = ENOENT;
++		return -1;
++	} else if (errno != ENAMETOOLONG)
++		return ret;
++
++	fd = openat_with_flags(dirfd, path, at_flags);
++	if (fd == -1)
++		return -1;
++	ret = listxattr(proc_self_fd_path(fd, &buffer), list, size);
++	close(fd);
++	return ret;
++}
+Index: acl/libmisc/proc-self-fd.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/proc-self-fd.c
+@@ -0,0 +1,92 @@
++/*
++  File: xattrat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <unistd.h>
++#include <fcntl.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <errno.h>
++#include "libmisc/proc-self-fd.h"
++
++char *
++proc_self_fd_path(int fd, struct proc_self_fd_buffer *buffer)
++{
++	sprintf(buffer->buffer, "/proc/self/fd/%d", fd);
++	return buffer->buffer;
++}
++
++void
++proc_self_fd_free(char *path, struct proc_self_fd_buffer *buffer)
++{
++	if (path != buffer->buffer)
++		free(path);
++}
++
++char *
++proc_self_fd_realpath(int dirfd, const char *path, int *at_flags,
++		      struct proc_self_fd_buffer *buffer)
++{
++	char *newpath;
++	int ret;
++
++	if (!*path) {
++		*at_flags &= ~AT_SYMLINK_NOFOLLOW;
++		return proc_self_fd_path(dirfd, buffer);
++	}
++	ret = asprintf(&newpath, "/proc/self/fd/%d/%s", dirfd, path);
++	if (ret == -1)
++		return NULL;
++	return newpath;
++}
++
++int
++openat_with_flags(int dirfd, const char *path, int at_flags)
++{
++	int flags = O_PATH | O_CLOEXEC;
++
++	if (at_flags & AT_SYMLINK_NOFOLLOW)
++		flags |= O_NOFOLLOW;
++	return openat(dirfd, path, flags);
++}
++
++/*
++ * getxattrat(), setxattrat(), listxattrat(), and removexattrat() up to at
++ * least kernel version 7.2 fail with EBADF when the dirfd is an O_PATH file
++ * descriptor and the pathname is NULL or empty.
++ */
++int
++need_slow_empty_paths(int dirfd, const char *path)
++{
++	int saved_errno = errno;
++	int open_flags;
++
++	if (errno != EBADF)
++		return 0;
++	if (*path)
++	       return 0;
++	open_flags = fcntl(dirfd, F_GETFL);
++	if (open_flags == -1) {
++		errno = saved_errno;
++		return 0;
++	}
++	if (!(open_flags & O_PATH))
++		return 0;
++	return 1;
++}
+Index: acl/libmisc/proc-self-fd.h
+===================================================================
+--- /dev/null
++++ acl/libmisc/proc-self-fd.h
+@@ -0,0 +1,31 @@
++#ifndef MISC_XATTRAT_COMPAT_H
++#define MISC_XATTRAT_COMPAT_H
++
++#include <limits.h>
++#include "include/visibility-hidden.h"
++
++/*
++ * The maximum number of decimal digits of an N-bit number is
++ * ceil(N * log10(2)), with log10(2) being approx. 0.30103.  We
++ * use 31/100 as a safe and close enough approximation; the
++ * overshoot even for 128-bit numbers is only one byte.
++ */
++#define TYPE_BITS(type) (sizeof(type) * CHAR_BIT)
++#define DECIMAL_DIGITS(type) ((TYPE_BITS(type) * 31 + 99) / 100)
++
++struct proc_self_fd_buffer {
++	char buffer[sizeof("/proc/self/fd/") +
++		    /* sign */ 1 + DECIMAL_DIGITS(int)];
++};
++
++hidden char *proc_self_fd_path(int fd, struct proc_self_fd_buffer *buffer);
++hidden void proc_self_fd_free(char *path, struct proc_self_fd_buffer *buffer);
++
++hidden extern int slow_empty_paths;
++
++hidden char *proc_self_fd_realpath(int dirfd, const char *path, int *at_flags,
++				   struct proc_self_fd_buffer *buffer);
++hidden int openat_with_flags(int dirfd, const char *path, int at_flags);
++hidden int need_slow_empty_paths(int dirfd, const char *path);
++
++#endif /* MISC_XATTRAT_COMPAT_H */
+Index: acl/libmisc/removexattrat_compat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/removexattrat_compat.c
+@@ -0,0 +1,107 @@
++/*
++  File: getxattrat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/xattr.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <errno.h>
++#include <stdlib.h>
++#include "xattrat.h"
++#include "libmisc/proc-self-fd.h"
++
++#define DECLARATIONS_ONLY
++#include "xattrat_compat.h"
++
++/* Defined in getxattrat_compat.c */
++extern int slow_empty_paths;
++
++static int
++xremovexattr(const char *path, int at_flags, const char *name)
++{
++	if (at_flags & AT_SYMLINK_NOFOLLOW)
++		return lremovexattr(path, name);
++	return removexattr(path, name);
++}
++
++
++int
++removexattrat_compat(int dirfd, const char *path, int at_flags,
++		     const char *name)
++{
++	struct proc_self_fd_buffer buffer;
++	static int no_removexattrat;
++	char *newpath;
++	int fd, ret;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++	if (!*path) {
++		if (!(at_flags & AT_EMPTY_PATH)) {
++			errno = ENOENT;
++			return -1;
++		}
++	}
++
++	if (dirfd == AT_FDCWD || *path == '/')
++		return xremovexattr(path, at_flags, name);
++
++	if (!no_removexattrat) {
++		if (!*path && slow_empty_paths)
++			goto proc_self_fd_path;
++		ret = removexattrat(dirfd, path, at_flags, name);
++		if (ret != -1)
++			return ret;
++		if (need_slow_empty_paths(dirfd, path)) {
++			slow_empty_paths = 1;
++			goto proc_self_fd_path;
++		}
++		if (errno != ENOSYS)
++			return ret;
++		no_removexattrat = 1;
++	}
++
++proc_self_fd_path:
++	newpath = proc_self_fd_realpath(dirfd, path, &at_flags, &buffer);
++	if (!newpath)
++		return -1;
++	ret = xremovexattr(newpath, at_flags, name);
++	proc_self_fd_free(newpath, &buffer);
++	if (ret != -1)
++		return ret;
++	if (errno == ENOENT) {
++		if (!*path) {
++			errno = EBADF;
++			return -1;
++		}
++		if (fcntl(dirfd, F_GETFL) != -1)
++			errno = ENOENT;
++		return -1;
++	} else if (errno != ENAMETOOLONG)
++		return ret;
++
++	fd = openat_with_flags(dirfd, path, at_flags);
++	if (fd == -1)
++		return -1;
++	ret = removexattr(proc_self_fd_path(fd, &buffer), name);
++	close(fd);
++	return ret;
++}
+Index: acl/libmisc/setxattrat_compat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/setxattrat_compat.c
+@@ -0,0 +1,108 @@
++/*
++  File: getxattrat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/xattr.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <errno.h>
++#include <stdlib.h>
++#include "xattrat.h"
++#include "libmisc/proc-self-fd.h"
++
++#define DECLARATIONS_ONLY
++#include "xattrat_compat.h"
++
++/* Defined in getxattrat_compat.c */
++extern int slow_empty_paths;
++
++static int
++xsetxattr(const char *path, int at_flags, const char *name, const void *value,
++	  size_t size, int flags)
++{
++	if (at_flags & AT_SYMLINK_NOFOLLOW)
++		return lsetxattr(path, name, value, size, flags);
++	return setxattr(path, name, value, size, flags);
++}
++
++int
++setxattrat_compat(int dirfd, const char *path, int at_flags, const char *name,
++		  const void *value, size_t size, int flags)
++{
++	struct proc_self_fd_buffer buffer;
++	static int no_setxattrat;
++	char *newpath;
++	int fd, ret;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++	if (!*path) {
++		if (!(at_flags & AT_EMPTY_PATH)) {
++			errno = ENOENT;
++			return -1;
++		}
++	}
++
++	if (dirfd == AT_FDCWD || *path == '/')
++		return xsetxattr(path, at_flags, name, value, size, flags);
++
++	if (!no_setxattrat) {
++		if (!*path && slow_empty_paths)
++			goto proc_self_fd_path;
++		ret = setxattrat(dirfd, path, at_flags, name, value, size,
++				 flags);
++		if (ret != -1)
++			return ret;
++		if (need_slow_empty_paths(dirfd, path)) {
++			slow_empty_paths = 1;
++			goto proc_self_fd_path;
++		}
++		if (errno != ENOSYS)
++			return ret;
++		no_setxattrat = 1;
++	}
++
++proc_self_fd_path:
++	newpath = proc_self_fd_realpath(dirfd, path, &at_flags, &buffer);
++	if (!newpath)
++		return -1;
++	ret = xsetxattr(newpath, at_flags, name, value, size, flags);
++	proc_self_fd_free(newpath, &buffer);
++	if (ret != -1)
++		return ret;
++	if (errno == ENOENT) {
++		if (!*path) {
++			errno = EBADF;
++			return -1;
++		}
++		if (fcntl(dirfd, F_GETFL) != -1)
++			errno = ENOENT;
++		return -1;
++	} else if (errno != ENAMETOOLONG)
++		return ret;
++
++	fd = openat_with_flags(dirfd, path, at_flags);
++	if (fd == -1)
++		return -1;
++	ret = setxattr(proc_self_fd_path(fd, &buffer), name, value, size, flags);
++	close(fd);
++	return ret;
++}

--- a/debian/patches/backport-0003-CVE-2026-54370.patch
+++ b/debian/patches/backport-0003-CVE-2026-54370.patch
@@ -1,0 +1,158 @@
+From c3492ef76587ce1e652bbb1bdf99f8ea6224b364 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Tue, 16 Jun 2026 22:44:07 +0200
+Subject: [PATCH] Add fchmodat syscall backwards compatibility code
+
+Support for the AT_SYMLINK_NOFOLLOW flag was added in commit 09da082b07bb
+("fs: Add fchmodat2()") and support for the AT_EMPTY_PATH flag was added in
+commit 5daeb41a6fc9d ("fchmodat2: add support for AT_EMPTY_PATH"), both
+merged in kernel version 6.6 from October 2023.
+
+Add a fchmodat_compat() wrapper that detects when the kernel doesn't support
+those features and fall back to chmod("/proc/self/fd/<dirfd>", mode) when
+necessary.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ include/Makemodule.am     |  1 +
+ include/fchmodat_compat.h | 12 ++++++
+ libmisc/Makemodule.am     |  1 +
+ libmisc/fchmodat_compat.c | 88 +++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 102 insertions(+)
+ create mode 100644 include/fchmodat_compat.h
+ create mode 100644 libmisc/fchmodat_compat.c
+
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -2,6 +2,7 @@ noinst_HEADERS += \
+ 	include/libacl.h \
+ 	include/acl.h \
+ 	include/acl_ea.h \
++	include/fchmodat_compat.h \
+ 	include/misc.h \
+ 	include/visibility-hidden.h \
+ 	include/walk_tree.h \
+Index: acl/include/fchmodat_compat.h
+===================================================================
+--- /dev/null
++++ acl/include/fchmodat_compat.h
+@@ -0,0 +1,12 @@
++#ifndef FCHMODAT_COMPAT_H
++#define FCHMODAT_COMPAT_H
++
++#include <fcntl.h>
++
++int fchmodat_compat(int dirfd, const char *pathname, mode_t mode, int flags);
++
++#ifndef DECLARATIONS_ONLY
++# define fchmodat fchmodat_compat
++#endif
++
++#endif /* FCHMODAT_COMPAT_H */
+Index: acl/libmisc/Makemodule.am
+===================================================================
+--- acl.orig/libmisc/Makemodule.am
++++ acl/libmisc/Makemodule.am
+@@ -4,6 +4,7 @@ libmisc_la_SOURCES = \
+ 	libmisc/uid_gid_lookup.c \
+ 	libmisc/high_water_alloc.c \
+ 	libmisc/next_line.c \
++	libmisc/fchmodat_compat.c \
+ 	libmisc/quote.c \
+ 	libmisc/unquote.c \
+ 	libmisc/walk_tree.c
+Index: acl/libmisc/fchmodat_compat.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/fchmodat_compat.c
+@@ -0,0 +1,88 @@
++/*
++  File: fchmodat_compat.c
++
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <unistd.h>
++#include <fcntl.h>
++#include <sys/stat.h>
++#include <errno.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include "libmisc/proc-self-fd.h"
++
++#define DECLARATIONS_ONLY
++#include "fchmodat_compat.h"
++
++/*
++ * Support for the AT_SYMLINK_NOFOLLOW flag was added in commit 09da082b07bb
++ * ("fs: Add fchmodat2()") and support for the AT_EMPTY_PATH flag was added in
++ * commit 5daeb41a6fc9d ("fchmodat2: add support for AT_EMPTY_PATH"), both
++ * merged in kernel version 6.6 from October 2023.
++ */
++
++static int no_symlink_nofollow;
++
++int fchmodat_compat(int dirfd, const char *pathname, mode_t mode, int flags)
++{
++	struct proc_self_fd_buffer buffer;
++	int fd = dirfd;
++	int ret;
++
++	if ((flags & AT_SYMLINK_NOFOLLOW) && no_symlink_nofollow)
++			goto no_symlink_nofollow;
++	if ((flags & AT_EMPTY_PATH) && no_symlink_nofollow) {
++		if (!*pathname)
++			goto proc_self_fd_path;
++		flags &= ~AT_EMPTY_PATH;
++	}
++	ret = fchmodat(dirfd, pathname, mode, flags);
++	if (ret != -1)
++		return ret;
++	if (errno == ENOTSUP && (flags & AT_SYMLINK_NOFOLLOW)) {
++		no_symlink_nofollow = 1;
++		goto no_symlink_nofollow;
++	}
++	if (errno == EINVAL && (flags & AT_EMPTY_PATH)) {
++		no_symlink_nofollow = 1;
++		goto proc_self_fd_path;
++	}
++	return ret;
++
++no_symlink_nofollow:
++	if (*pathname) {
++		int open_flags = O_PATH | O_CLOEXEC;
++		if (flags & AT_SYMLINK_NOFOLLOW)
++			open_flags |= O_NOFOLLOW;
++		fd = openat(dirfd, pathname, open_flags);
++		if (fd == -1)
++			return -1;
++	}
++	/* fall through */
++
++proc_self_fd_path:
++	ret = chmod(proc_self_fd_path(fd, &buffer), mode);
++	if (ret == -1 && errno == ENOENT)
++		errno = EBADF;
++	if (fd != dirfd) {
++		int saved_errno = errno;
++		close(fd);
++		errno = saved_errno;
++	}
++	return ret;
++}

--- a/debian/patches/backport-0004-CVE-2026-54369.patch
+++ b/debian/patches/backport-0004-CVE-2026-54369.patch
@@ -1,0 +1,106 @@
+From 2bd96f3f5019a24fb2f144d07337008a8fb9332e Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Wed, 3 Jun 2026 19:52:12 +0200
+Subject: [PATCH] Remove unnecessary byteorder.h includes
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ libacl/__acl_extended_file.c | 2 --
+ libacl/acl_delete_def_file.c | 1 -
+ libacl/acl_extended_fd.c     | 2 --
+ libacl/acl_get_fd.c          | 2 --
+ libacl/acl_get_file.c        | 2 --
+ libacl/acl_set_fd.c          | 2 --
+ libacl/acl_set_file.c        | 2 --
+ 7 files changed, 13 deletions(-)
+
+Index: acl/libacl/__acl_extended_file.c
+===================================================================
+--- acl.orig/libacl/__acl_extended_file.c
++++ acl/libacl/__acl_extended_file.c
+@@ -22,8 +22,6 @@
+ #include <unistd.h>
+ #include <sys/xattr.h>
+ #include "libacl.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ #include "__acl_extended_file.h"
+ 
+Index: acl/libacl/acl_delete_def_file.c
+===================================================================
+--- acl.orig/libacl/acl_delete_def_file.c
++++ acl/libacl/acl_delete_def_file.c
+@@ -21,7 +21,6 @@
+ #include "config.h"
+ #include <sys/types.h>
+ #include <sys/xattr.h>
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ #include "libacl.h"
+ 
+Index: acl/libacl/acl_extended_fd.c
+===================================================================
+--- acl.orig/libacl/acl_extended_fd.c
++++ acl/libacl/acl_extended_fd.c
+@@ -22,8 +22,6 @@
+ #include <unistd.h>
+ #include <sys/xattr.h>
+ #include "libacl.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ 
+ int
+Index: acl/libacl/acl_get_fd.c
+===================================================================
+--- acl.orig/libacl/acl_get_fd.c
++++ acl/libacl/acl_get_fd.c
+@@ -26,8 +26,6 @@
+ #include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_from_xattr.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ 
+ /* 23.4.15 */
+Index: acl/libacl/acl_get_file.c
+===================================================================
+--- acl.orig/libacl/acl_get_file.c
++++ acl/libacl/acl_get_file.c
+@@ -26,8 +26,6 @@
+ #include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_from_xattr.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ 
+ /* 23.4.16 */
+Index: acl/libacl/acl_set_fd.c
+===================================================================
+--- acl.orig/libacl/acl_set_fd.c
++++ acl/libacl/acl_set_fd.c
+@@ -23,8 +23,6 @@
+ #include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_to_xattr.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ 
+ 
+Index: acl/libacl/acl_set_file.c
+===================================================================
+--- acl.orig/libacl/acl_set_file.c
++++ acl/libacl/acl_set_file.c
+@@ -25,8 +25,6 @@
+ #include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_to_xattr.h"
+-
+-#include "byteorder.h"
+ #include "acl_ea.h"
+ 
+ 

--- a/debian/patches/backport-0004-CVE-2026-54370.patch
+++ b/debian/patches/backport-0004-CVE-2026-54370.patch
@@ -1,0 +1,29 @@
+From e916e6f0c73947651233a2c1d836ac6e161298f4 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Wed, 31 Jan 2024 23:56:01 -0500
+Subject: [PATCH] libmisc: internalize walk_tree API
+
+While shared libs take care of hiding these symbols from the exported
+list, they can still show up in static linking and cause collisions.
+The codebase is using __acl_ as a prefix for other internal symbols,
+so rename these to match.
+
+We can cheat here with a define so the rest of the codebase doesn't
+need to be changed to the more verbose form.
+---
+ include/walk_tree.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: acl/include/walk_tree.h
+===================================================================
+--- acl.orig/include/walk_tree.h
++++ acl/include/walk_tree.h
+@@ -33,6 +33,8 @@
+ 
+ struct stat;
+ 
++#define walk_tree __acl_walk_tree
++
+ extern int walk_tree(const char *path, int walk_flags, unsigned int num,
+ 		     int (*func)(const char *, const struct stat *, int,
+ 				 void *), void *arg);

--- a/debian/patches/backport-0005-CVE-2026-54369.patch
+++ b/debian/patches/backport-0005-CVE-2026-54369.patch
@@ -1,0 +1,174 @@
+From a26029a5b4351fbf4b884a8e6454802f6481a0bf Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Thu, 4 Jun 2026 13:28:39 +0200
+Subject: [PATCH] Retry harder in acl_get_{file,fd}
+
+In acl_get_file() and acl_get_fd(), we first try to get acls that contain up to
+16 entries.  When that fails, we query the actual acl size, allocate the
+necessary space, and retry.  That fails if the file is assigned an even larger
+acl between querying the size and getting the acl.
+
+To prevent this race, retry several (8) times when the allocated buffer turns
+out to be too small.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ libacl/acl_get_fd.c   | 48 ++++++++++++++++++++++---------------
+ libacl/acl_get_file.c | 56 +++++++++++++++++++++++++------------------
+ 2 files changed, 62 insertions(+), 42 deletions(-)
+
+Index: acl/libacl/acl_get_fd.c
+===================================================================
+--- acl.orig/libacl/acl_get_fd.c
++++ acl/libacl/acl_get_fd.c
+@@ -32,33 +32,43 @@
+ acl_t
+ acl_get_fd(int fd)
+ {
+-	const size_t size_guess = acl_ea_size(16);
+-	char *ext_acl_p = alloca(size_guess);
++	size_t size_guess = acl_ea_size(16);
++	char *onstack_buffer = alloca(size_guess);
++	char *ext_acl_p = onstack_buffer;
++	acl_t acl = NULL;
++	int retries = 0;
+ 	int retval;
+ 
+-	if (!ext_acl_p)
+-		return NULL;
+-	retval = fgetxattr(fd, ACL_EA_ACCESS, ext_acl_p, size_guess);
+-	if (retval == -1 && errno == ERANGE) {
++	for (;;) {
++		retval = fgetxattr(fd, ACL_EA_ACCESS, ext_acl_p, size_guess);
++		if (retval != -1 || errno != ERANGE)
++			break;
++		if (++retries >= 8)
++			break;
++
+ 		retval = fgetxattr(fd, ACL_EA_ACCESS, NULL, 0);
+-		if (retval > 0) {
+-			ext_acl_p = alloca(retval);
+-			if (!ext_acl_p)
+-				return NULL;
+-			retval = fgetxattr(fd, ACL_EA_ACCESS, ext_acl_p,retval);
+-		}
++		if (retval <= 0)
++			break;
++		size_guess = retval;
++
++		if (ext_acl_p != onstack_buffer)
++			free(ext_acl_p);
++		ext_acl_p = malloc(size_guess);
++		if (!ext_acl_p)
++			goto out;
+ 	}
+ 	if (retval > 0) {
+-		acl_t acl = __acl_from_xattr(ext_acl_p, retval);
+-		return acl;
++		acl = __acl_from_xattr(ext_acl_p, retval);
+ 	} else if (retval == 0 || errno == ENOATTR || errno == ENODATA) {
+ 		struct stat st;
+ 
+ 		if (fstat(fd, &st) == 0)
+-			return acl_from_mode(st.st_mode);
+-		else
+-			return NULL;
+-	} else
+-		return NULL;
++			acl = acl_from_mode(st.st_mode);
++	}
++
++out:
++	if (ext_acl_p != onstack_buffer)
++		free(ext_acl_p);
++	return acl;
+ }
+ 
+Index: acl/libacl/acl_get_file.c
+===================================================================
+--- acl.orig/libacl/acl_get_file.c
++++ acl/libacl/acl_get_file.c
+@@ -32,9 +32,12 @@
+ acl_t
+ acl_get_file(const char *path_p, acl_type_t type)
+ {
+-	const size_t size_guess = acl_ea_size(16);
+-	char *ext_acl_p = alloca(size_guess);
++	size_t size_guess = acl_ea_size(16);
++	char *onstack_buffer = alloca(size_guess);
++	char *ext_acl_p = onstack_buffer;
+ 	const char *name;
++	acl_t acl = NULL;
++	int retries = 0;
+ 	int retval;
+ 
+ 	switch(type) {
+@@ -46,40 +49,47 @@ acl_get_file(const char *path_p, acl_typ
+ 			break;
+ 		default:
+ 			errno = EINVAL;
+-			return NULL;
++			goto out;
+ 	}
+ 
+-	if (!ext_acl_p)
+-		return NULL;
+-	retval = getxattr(path_p, name, ext_acl_p, size_guess);
+-	if (retval == -1 && errno == ERANGE) {
++	for (;;) {
++		retval = getxattr(path_p, name, ext_acl_p, size_guess);
++		if (retval != -1 || errno != ERANGE)
++			break;
++		if (++retries >= 8)
++			break;
++
+ 		retval = getxattr(path_p, name, NULL, 0);
+-		if (retval > 0) {
+-			ext_acl_p = alloca(retval);
+-			if (!ext_acl_p)
+-				return NULL;
+-			retval = getxattr(path_p, name, ext_acl_p, retval);
+-		}
++		if (retval <= 0)
++			break;
++		size_guess = retval;
++
++		if (ext_acl_p != onstack_buffer)
++			free(ext_acl_p);
++		ext_acl_p = malloc(size_guess);
++		if (!ext_acl_p)
++			goto out;
+ 	}
+ 	if (retval > 0) {
+-		acl_t acl = __acl_from_xattr(ext_acl_p, retval);
+-		return acl;
++		acl = __acl_from_xattr(ext_acl_p, retval);
+ 	} else if (retval == 0 || errno == ENOATTR || errno == ENODATA) {
+ 		struct stat st;
+ 
+ 		if (stat(path_p, &st) != 0)
+-			return NULL;
++			goto out;
+ 
+ 		if (type == ACL_TYPE_DEFAULT) {
+ 			if (S_ISDIR(st.st_mode))
+-				return acl_init(0);
+-			else {
++				acl = acl_init(0);
++			else
+ 				errno = EACCES;
+-				return NULL;
+-			}
+ 		} else
+-			return acl_from_mode(st.st_mode);
+-	} else
+-		return NULL;
++			acl = acl_from_mode(st.st_mode);
++	}
++
++out:
++	if (ext_acl_p != onstack_buffer)
++		free(ext_acl_p);
++	return acl;
+ }
+ 

--- a/debian/patches/backport-0005-CVE-2026-54370.patch
+++ b/debian/patches/backport-0005-CVE-2026-54370.patch
@@ -1,0 +1,3321 @@
+From f55ec6b2e6b9094414b41df67bd19cbbfd48e8be Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Thu, 11 Jun 2026 14:04:17 +0200
+Subject: [PATCH] Use .run as the filename extension for "run" test scripts
+
+Rename all test scripts executed by the "run" utility from *.test to *.run and
+define how to execute those tests.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ test/Makemodule.am                            | 38 ++++++++++---------
+ test/{cp.test => cp.run}                      |  0
+ test/{getfacl-lfs.test => getfacl-lfs.run}    |  0
+ .../{getfacl-noacl.test => getfacl-noacl.run} |  0
+ ...l-recursive.test => getfacl-recursive.run} |  0
+ ...med-restore.test => malformed-restore.run} |  0
+ test/{misc.test => misc.run}                  |  0
+ test/nfs/{nfs-dir.test => nfs-dir.run}        |  0
+ test/nfs/{nfsacl.test => nfsacl.run}          |  0
+ test/root/{getfacl.test => getfacl.run}       |  0
+ .../{permissions.test => permissions.run}     |  0
+ test/root/{restore.test => restore.run}       |  0
+ test/root/{setfacl.test => setfacl.run}       |  0
+ .../{sbits-restore.test => sbits-restore.run} |  0
+ test/{setfacl-X.test => setfacl-X.run}        |  0
+ ...utf8-filenames.test => utf8-filenames.run} |  0
+ 16 files changed, 21 insertions(+), 17 deletions(-)
+ rename test/{cp.test => cp.run} (100%)
+ rename test/{getfacl-lfs.test => getfacl-lfs.run} (100%)
+ rename test/{getfacl-noacl.test => getfacl-noacl.run} (100%)
+ rename test/{getfacl-recursive.test => getfacl-recursive.run} (100%)
+ rename test/{malformed-restore.test => malformed-restore.run} (100%)
+ rename test/{misc.test => misc.run} (100%)
+ rename test/nfs/{nfs-dir.test => nfs-dir.run} (100%)
+ rename test/nfs/{nfsacl.test => nfsacl.run} (100%)
+ rename test/root/{getfacl.test => getfacl.run} (100%)
+ rename test/root/{permissions.test => permissions.run} (100%)
+ rename test/root/{restore.test => restore.run} (100%)
+ rename test/root/{setfacl.test => setfacl.run} (100%)
+ rename test/{sbits-restore.test => sbits-restore.run} (100%)
+ rename test/{setfacl-X.test => setfacl-X.run} (100%)
+ rename test/{utf8-filenames.test => utf8-filenames.run} (100%)
+
+Index: acl/test/Makemodule.am
+===================================================================
+--- acl.orig/test/Makemodule.am
++++ acl/test/Makemodule.am
+@@ -1,20 +1,22 @@
++TEST_EXTENSIONS = .run
++
+ XFAIL_TESTS = \
+-	test/nfs/nfsacl.test \
+-	test/nfs/nfs-dir.test
++	test/nfs/nfsacl.run \
++	test/nfs/nfs-dir.run
+ TESTS = \
+-	test/cp.test \
+-	test/getfacl-lfs.test \
+-	test/getfacl-noacl.test \
+-	test/getfacl-recursive.test \
+-	test/malformed-restore.test \
+-	test/misc.test \
+-	test/sbits-restore.test \
+-	test/setfacl-X.test \
+-	test/utf8-filenames.test \
+-	test/root/getfacl.test \
+-	test/root/permissions.test \
+-	test/root/restore.test \
+-	test/root/setfacl.test \
++	test/cp.run \
++	test/getfacl-lfs.run \
++	test/getfacl-noacl.run \
++	test/getfacl-recursive.run \
++	test/malformed-restore.run \
++	test/misc.run \
++	test/sbits-restore.run \
++	test/setfacl-X.run \
++	test/utf8-filenames.run \
++	test/root/getfacl.run \
++	test/root/permissions.run \
++	test/root/restore.run \
++	test/root/setfacl.run \
+ 	$(XFAIL_TESTS)
+ 
+ EXTRA_DIST += \
+Index: acl/test/cp.run
+===================================================================
+--- /dev/null
++++ acl/test/cp.run
+@@ -0,0 +1,46 @@
++The cp utility should only copy ACLs if `-p' is given.
++ 
++	$ umask 022
++	$ mkdir d
++	$ cd d
++	$ touch f
++	$ setfacl -m u:bin:rw f
++	$ ls -l f | awk -- '{ print $1 }'
++	> -rw-rw-r--+
++	
++	$ cp f g
++	$ ls -l g | awk -- '{ print $1 }' | sed 's/\\.$//g'
++	> -rw-r--r--
++	
++	$ rm g
++	$ cp -p f g
++	$ ls -l g | awk -- '{ print $1 }'
++	> -rw-rw-r--+
++	
++	$ mkdir h
++	$ echo blubb > h/x
++	$ cp -rp h i
++	$ cat i/x
++	> blubb
++
++	$ rm -r i
++	$ setfacl -R -m u:bin:rwx h
++	$ getfacl --omit-header h/x
++	> user::rw-
++	> user:bin:rwx
++	> group::r--
++	> mask::rwx
++	> other::r--
++	>
++
++	$ cp -rp h i
++	$ getfacl --omit-header i/x
++	> user::rw-
++	> user:bin:rwx
++	> group::r--
++	> mask::rwx
++	> other::r--
++	>
++
++	$ cd ..
++	$ rm -r d
+Index: acl/test/cp.test
+===================================================================
+--- acl.orig/test/cp.test
++++ /dev/null
+@@ -1,46 +0,0 @@
+-The cp utility should only copy ACLs if `-p' is given.
+- 
+-	$ umask 022
+-	$ mkdir d
+-	$ cd d
+-	$ touch f
+-	$ setfacl -m u:bin:rw f
+-	$ ls -l f | awk -- '{ print $1 }'
+-	> -rw-rw-r--+
+-	
+-	$ cp f g
+-	$ ls -l g | awk -- '{ print $1 }' | sed 's/\\.$//g'
+-	> -rw-r--r--
+-	
+-	$ rm g
+-	$ cp -p f g
+-	$ ls -l g | awk -- '{ print $1 }'
+-	> -rw-rw-r--+
+-	
+-	$ mkdir h
+-	$ echo blubb > h/x
+-	$ cp -rp h i
+-	$ cat i/x
+-	> blubb
+-
+-	$ rm -r i
+-	$ setfacl -R -m u:bin:rwx h
+-	$ getfacl --omit-header h/x
+-	> user::rw-
+-	> user:bin:rwx
+-	> group::r--
+-	> mask::rwx
+-	> other::r--
+-	>
+-
+-	$ cp -rp h i
+-	$ getfacl --omit-header i/x
+-	> user::rw-
+-	> user:bin:rwx
+-	> group::r--
+-	> mask::rwx
+-	> other::r--
+-	>
+-
+-	$ cd ..
+-	$ rm -r d
+Index: acl/test/getfacl-lfs.run
+===================================================================
+--- /dev/null
++++ acl/test/getfacl-lfs.run
+@@ -0,0 +1,7 @@
++Check getfacl large-file support.
++This test can be run on a filesystem with large-file support.
++
++	$ umask 027
++	$ dd bs=65536 seek=32768 if=/dev/null of=large-file 2>/dev/null ||:
++	$ sh -c 'if test -f large-file; then getfacl large-file >/dev/null; fi'
++	$ rm large-file
+Index: acl/test/getfacl-lfs.test
+===================================================================
+--- acl.orig/test/getfacl-lfs.test
++++ /dev/null
+@@ -1,7 +0,0 @@
+-Check getfacl large-file support.
+-This test can be run on a filesystem with large-file support.
+-
+-	$ umask 027
+-	$ dd bs=65536 seek=32768 if=/dev/null of=large-file 2>/dev/null ||:
+-	$ sh -c 'if test -f large-file; then getfacl large-file >/dev/null; fi'
+-	$ rm large-file
+Index: acl/test/getfacl-noacl.run
+===================================================================
+--- /dev/null
++++ acl/test/getfacl-noacl.run
+@@ -0,0 +1,55 @@
++Getfacl utility option parsing tests. This test can be run on a
++filesystem with or without ACL support.
++
++	$ mkdir test
++	$ cd test
++	$ umask 027
++	$ touch x
++	$ getfacl --omit-header x
++	> user::rw-
++	> group::r--
++	> other::---
++	> 
++
++	$ getfacl --omit-header --access x
++	> user::rw-
++	> group::r--
++	> other::---
++	> 
++
++	$ getfacl --omit-header -d x
++	$ getfacl --omit-header -d .
++	$ getfacl --omit-header -d /
++	> getfacl: Removing leading '/' from absolute path names
++	
++	$ getfacl --skip-base x
++	$ getfacl --omit-header --all-effective x
++	> user::rw-
++	> group::r--
++	> other::---
++	> 
++	
++	$ getfacl --omit-header --no-effective x
++	> user::rw-
++	> group::r--
++	> other::---
++	> 
++	
++	$ mkdir d
++	$ touch d/y
++	$ ln -s d l
++	$ getfacl -dR . | grep file | sort
++	> # file: .
++	> # file: d
++	> # file: d/y
++	> # file: x
++	
++	$ ln -s l ll
++	$ getfacl -dLR ll | grep file | sort
++	> # file: ll
++	> # file: ll/y
++	
++	$ rm l ll x
++	$ rm -rf d
++	$ cd ..
++	$ rmdir test
+Index: acl/test/getfacl-noacl.test
+===================================================================
+--- acl.orig/test/getfacl-noacl.test
++++ /dev/null
+@@ -1,55 +0,0 @@
+-Getfacl utility option parsing tests. This test can be run on a
+-filesystem with or without ACL support.
+-
+-	$ mkdir test
+-	$ cd test
+-	$ umask 027
+-	$ touch x
+-	$ getfacl --omit-header x
+-	> user::rw-
+-	> group::r--
+-	> other::---
+-	> 
+-
+-	$ getfacl --omit-header --access x
+-	> user::rw-
+-	> group::r--
+-	> other::---
+-	> 
+-
+-	$ getfacl --omit-header -d x
+-	$ getfacl --omit-header -d .
+-	$ getfacl --omit-header -d /
+-	> getfacl: Removing leading '/' from absolute path names
+-	
+-	$ getfacl --skip-base x
+-	$ getfacl --omit-header --all-effective x
+-	> user::rw-
+-	> group::r--
+-	> other::---
+-	> 
+-	
+-	$ getfacl --omit-header --no-effective x
+-	> user::rw-
+-	> group::r--
+-	> other::---
+-	> 
+-	
+-	$ mkdir d
+-	$ touch d/y
+-	$ ln -s d l
+-	$ getfacl -dR . | grep file | sort
+-	> # file: .
+-	> # file: d
+-	> # file: d/y
+-	> # file: x
+-	
+-	$ ln -s l ll
+-	$ getfacl -dLR ll | grep file | sort
+-	> # file: ll
+-	> # file: ll/y
+-	
+-	$ rm l ll x
+-	$ rm -rf d
+-	$ cd ..
+-	$ rmdir test
+Index: acl/test/getfacl-recursive.run
+===================================================================
+--- /dev/null
++++ acl/test/getfacl-recursive.run
+@@ -0,0 +1,195 @@
++Tests for proper path recursion
++
++	$ umask 022
++	$ mkdir -p 1/2/3
++	$ mkdir 1/link
++	$ touch 1/link/file
++	$ ln -s `pwd`/1/link 1/2/link
++	$ getfacl -P -R 1/2 | sort-getfacl-output
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++
++	$ getfacl -R 1/2 | sort-getfacl-output
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++
++	$ getfacl -R -L 1/2 | sort-getfacl-output
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/link
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/link/file
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rw-
++	> group::r--
++	> other::r--
++	>
++
++	$ getfacl -P -R 1 | sort-getfacl-output
++	> # file: 1
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/link
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/link/file
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rw-
++	> group::r--
++	> other::r--
++	>
++
++	$ getfacl -R 1 | sort-getfacl-output
++	> # file: 1
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/link
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/link/file
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rw-
++	> group::r--
++	> other::r--
++	>
++
++	$ getfacl -R -L 1 | sort-getfacl-output
++	> # file: 1
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/3
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/link
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/2/link/file
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rw-
++	> group::r--
++	> other::r--
++	>
++	> # file: 1/link
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	> # file: 1/link/file
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rw-
++	> group::r--
++	> other::r--
++	>
++
++	$ rm -R 1/
+Index: acl/test/getfacl-recursive.test
+===================================================================
+--- acl.orig/test/getfacl-recursive.test
++++ /dev/null
+@@ -1,195 +0,0 @@
+-Tests for proper path recursion
+-
+-	$ umask 022
+-	$ mkdir -p 1/2/3
+-	$ mkdir 1/link
+-	$ touch 1/link/file
+-	$ ln -s `pwd`/1/link 1/2/link
+-	$ getfacl -P -R 1/2 | sort-getfacl-output
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-
+-	$ getfacl -R 1/2 | sort-getfacl-output
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-
+-	$ getfacl -R -L 1/2 | sort-getfacl-output
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/link
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/link/file
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rw-
+-	> group::r--
+-	> other::r--
+-	>
+-
+-	$ getfacl -P -R 1 | sort-getfacl-output
+-	> # file: 1
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/link
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/link/file
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rw-
+-	> group::r--
+-	> other::r--
+-	>
+-
+-	$ getfacl -R 1 | sort-getfacl-output
+-	> # file: 1
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/link
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/link/file
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rw-
+-	> group::r--
+-	> other::r--
+-	>
+-
+-	$ getfacl -R -L 1 | sort-getfacl-output
+-	> # file: 1
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/3
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/link
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/2/link/file
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rw-
+-	> group::r--
+-	> other::r--
+-	>
+-	> # file: 1/link
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	> # file: 1/link/file
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rw-
+-	> group::r--
+-	> other::r--
+-	>
+-
+-	$ rm -R 1/
+Index: acl/test/malformed-restore.run
+===================================================================
+--- /dev/null
++++ acl/test/malformed-restore.run
+@@ -0,0 +1,19 @@
++Test for malformed input to --restore
++ https://savannah.nongnu.org/bugs/index.php?28185
++
++	$ cp "%TESTDIR/malformed-restore-double-owner.acl" tmp.acl
++	$ sed -i "s/USER/%TUSER/g" tmp.acl
++	$ sed -i "s/GROUP/%TGROUP/g" tmp.acl
++	$ touch tmp
++	$ setfacl --restore tmp.acl
++	> setfacl: tmp.acl: Invalid argument
++	$ rm tmp.acl tmp
++
++	$ mkdir tmp
++	$ chmod 1777 tmp
++	$ getfacl tmp > tmp.acl
++	$ sed -i 's/--t/--x/g' tmp.acl
++	$ setfacl --restore tmp.acl
++	> setfacl: tmp.acl: Invalid argument
++	$ rmdir tmp
++	$ rm tmp.acl
+Index: acl/test/malformed-restore.test
+===================================================================
+--- acl.orig/test/malformed-restore.test
++++ /dev/null
+@@ -1,19 +0,0 @@
+-Test for malformed input to --restore
+- https://savannah.nongnu.org/bugs/index.php?28185
+-
+-	$ cp "%TESTDIR/malformed-restore-double-owner.acl" tmp.acl
+-	$ sed -i "s/USER/%TUSER/g" tmp.acl
+-	$ sed -i "s/GROUP/%TGROUP/g" tmp.acl
+-	$ touch tmp
+-	$ setfacl --restore tmp.acl
+-	> setfacl: tmp.acl: Invalid argument
+-	$ rm tmp.acl tmp
+-
+-	$ mkdir tmp
+-	$ chmod 1777 tmp
+-	$ getfacl tmp > tmp.acl
+-	$ sed -i 's/--t/--x/g' tmp.acl
+-	$ setfacl --restore tmp.acl
+-	> setfacl: tmp.acl: Invalid argument
+-	$ rmdir tmp
+-	$ rm tmp.acl
+Index: acl/test/misc.run
+===================================================================
+--- /dev/null
++++ acl/test/misc.run
+@@ -0,0 +1,501 @@
++Pretty comprehensive ACL tests.
++ 
++This must be run on a filesystem with ACL support. Also, you will need
++two dummy users (bin and daemon) and a dummy group (daemon).
++ 
++	$ rm -f f
++	$ umask 027
++	$ touch f
++	  
++Only change a base ACL:
++	$ chacl u::rw,g::r,o::- f
++	$ setfacl -m u::r f
++	$ setfacl -m u::rw,u:bin:rw f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw----+
++	
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> group::r--
++	> mask::rw-
++	> other::---
++	> 
++
++	$ rm f
++	$ umask 022
++	$ touch f
++	$ setfacl -m u:bin:rw f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw-r--+
++
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> group::r--
++	> mask::rw-
++	> other::r--
++	> 
++
++	$rm f
++	$ umask 027
++	$ mkdir d
++	$ setfacl -m u:bin:rwx d
++	$ ls -dl d | awk '{print $1}'
++	> drwxrwx---+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::---
++	> 
++
++	$ rmdir d
++	$ umask 022
++	$ mkdir d
++	$ setfacl -m u:bin:rwx d
++	$ ls -dl d | awk '{print $1}'
++	> drwxrwxr-x+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	> 
++
++	$ rmdir d
++	 
++
++Multiple users
++	 
++	$ umask 022
++	$ touch f
++	$ setfacl -m u:bin:rw,u:daemon:r f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw-r--+
++
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> user:daemon:r--
++	> group::r--
++	> mask::rw-
++	> other::r--
++	> 
++	 
++Multiple groups
++	 
++	$ setfacl -m g:users:rw,g:daemon:r f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw-r--+
++
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> user:daemon:r--
++	> group::r--
++	> group:daemon:r--
++	> group:users:rw-
++	> mask::rw-
++	> other::r--
++	> 
++	 
++Remove one group
++	 
++	$ setfacl -x g:users f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw-r--+
++
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> user:daemon:r--
++	> group::r--
++	> group:daemon:r--
++	> mask::rw-
++	> other::r--
++	> 
++	 
++Remove one user
++	 
++	$ setfacl -x u:daemon f
++	$ ls -dl f | awk '{print $1}'
++	> -rw-rw-r--+
++
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:bin:rw-
++	> group::r--
++	> group:daemon:r--
++	> mask::rw-
++	> other::r--
++	> 
++
++	$ rm f
++	 
++Default ACL
++	 
++	$ umask 027
++	$ mkdir d
++	$ setfacl -m u:bin:rwx,u:daemon:rw,d:u:bin:rwx,d:m:rx d
++	$ ls -dl d | awk '{print $1}'
++	> drwxrwx---+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:rwx
++	> user:daemon:rw-
++	> group::r-x
++	> mask::rwx
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++	 
++Umask now ignored?
++ 
++	$ umask 027
++	$ touch d/f
++	$ ls -dl d/f | awk '{print $1}'
++	> -rw-r-----+
++
++	$ getfacl --omit-header d/f
++	> user::rw-
++	> user:bin:rwx	#effective:r--
++	> group::r-x	#effective:r--
++	> mask::r--
++	> other::---
++	> 
++
++	$ rm d/f
++	$ umask 022
++	$ touch d/f
++	$ ls -dl d/f | awk '{print $1}'
++	> -rw-r-----+
++
++	$ getfacl --omit-header d/f
++	> user::rw-
++	> user:bin:rwx	#effective:r--
++	> group::r-x	#effective:r--
++	> mask::r--
++	> other::---
++	> 
++
++	$ rm d/f
++	 
++Default ACL copying
++ 
++	$ umask 000
++	$ mkdir d/d
++	$ ls -dl d/d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/d
++	> user::rwx
++	> user:bin:rwx	#effective:r-x
++	> group::r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++
++	$ rmdir d/d
++	$ umask 022
++	$ mkdir d/d
++	$ ls -dl d/d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/d
++	> user::rwx
++	> user:bin:rwx	#effective:r-x
++	> group::r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++	 
++Add some users and groups
++ 
++	$ setfacl -nm u:daemon:rx,d:u:daemon:rx,g:users:rx,g:daemon:rwx d/d
++	$ ls -dl d/d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/d
++	> user::rwx
++	> user:bin:rwx	#effective:r-x
++	> user:daemon:r-x
++	> group::r-x
++	> group:daemon:rwx	#effective:r-x
++	> group:users:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:user:daemon:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++	 
++Symlink in directory with default ACL?
++	 
++	$ ln -s d d/l
++	$ ls -dl d/l | awk '{print $1}' | sed 's/\\.$//g'
++	> lrwxrwxrwx
++
++	$ ls -dl -L d/l | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/l
++	> user::rwx
++	> user:bin:rwx	#effective:r-x
++	> user:daemon:r-x
++	> group::r-x
++	> group:daemon:rwx	#effective:r-x
++	> group:users:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:user:daemon:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++
++	$ rm d/l
++	 
++Does mask manipulation work?
++	 
++	$ setfacl -m g:daemon:rx,u:bin:rx d/d
++	$ ls -dl d/d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/d
++	> user::rwx
++	> user:bin:r-x
++	> user:daemon:r-x
++	> group::r-x
++	> group:daemon:r-x
++	> group:users:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx	#effective:r-x
++	> default:user:daemon:r-x
++	> default:group::r-x
++	> default:mask::r-x
++	> default:other::---
++	> 
++
++	$ setfacl -m d:u:bin:rwx d/d
++	$ ls -dl d/d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d/d
++	> user::rwx
++	> user:bin:r-x
++	> user:daemon:r-x
++	> group::r-x
++	> group:daemon:r-x
++	> group:users:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:rwx
++	> default:user:daemon:r-x
++	> default:group::r-x
++	> default:mask::rwx
++	> default:other::---
++	> 
++
++	$ rmdir d/d
++	 
++Remove the default ACL
++	 
++	$ setfacl -k d
++	$ ls -dl d | awk '{print $1}'
++	> drwxrwx---+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:rwx
++	> user:daemon:rw-
++	> group::r-x
++	> mask::rwx
++	> other::---
++	> 
++	 
++Reset to base entries
++	 
++	$ setfacl -b d
++	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
++	> drwxr-x---
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> group::r-x
++	> other::---
++	> 
++	 
++Now, chmod should change the group_obj entry
++	 
++	$ chmod 775 d
++	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
++	> drwxrwxr-x
++	
++	$ getfacl --omit-header d
++	> user::rwx
++	> group::rwx
++	> other::r-x
++	> 
++
++	$ rmdir d
++	$ umask 002
++	$ mkdir d
++	$ setfacl -m u:daemon:rwx,u:bin:rx,d:u:daemon:rwx,d:u:bin:rx d
++	$ ls -dl d | awk '{print $1}'
++	> drwxrwxr-x+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:r-x
++	> user:daemon:rwx
++	> group::rwx
++	> mask::rwx
++	> other::r-x
++	> default:user::rwx
++	> default:user:bin:r-x
++	> default:user:daemon:rwx
++	> default:group::rwx
++	> default:mask::rwx
++	> default:other::r-x
++	> 
++
++	$ chmod 750 d
++	$ ls -dl d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:r-x
++	> user:daemon:rwx	#effective:r-x
++	> group::rwx	#effective:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:r-x
++	> default:user:daemon:rwx
++	> default:group::rwx
++	> default:mask::rwx
++	> default:other::r-x
++	> 
++
++	$ chmod 750 d
++	$ ls -dl d | awk '{print $1}'
++	> drwxr-x---+
++
++	$ getfacl --omit-header d
++	> user::rwx
++	> user:bin:r-x
++	> user:daemon:rwx	#effective:r-x
++	> group::rwx	#effective:r-x
++	> mask::r-x
++	> other::---
++	> default:user::rwx
++	> default:user:bin:r-x
++	> default:user:daemon:rwx
++	> default:group::rwx
++	> default:mask::rwx
++	> default:other::r-x
++	> 
++
++	$ rmdir d
++
++Dangling symlink test https://savannah.nongnu.org/bugs/?28131
++
++	$ mkdir d
++	$ ln -s d/a d/b
++	$ getfacl -R d
++	> # file: d
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> group::rwx
++	> other::r-x
++	> 
++	$ setfacl -R -m u:bin:rw d
++	$ getfacl -RL d
++	> getfacl: d/b: No such file or directory
++	> # file: d
++	> # owner: %TUSER
++	> # group: %TGROUP
++	> user::rwx
++	> user:bin:rw-
++	> group::rwx
++	> mask::rwx
++	> other::r-x
++	> 
++	$ setfacl -RL -m u:bin:rw d
++	> setfacl: d/b: No such file or directory
++	$ rm -R d
++
++Handle escaped literal backslash followed by numeric username
++	$ mkdir d
++	$ touch d/f
++	$ setfacl -m u:domain\\\\12345:rw- d/f
++	$ getfacl --omit-header d/f
++	> user::rw-
++	> user:domain\\12345:rw-
++	> group::rw-
++	> mask::rw-
++	> other::r--
++	> 
++	$ rm -R d
++
++Handle escaped literal backslash
++	$ mkdir d
++	$ touch d/f
++	$ setfacl -m u:domain\\\\user:rw- d/f
++	$ getfacl --omit-header d/f
++	> user::rw-
++	> user:domain\\user:rw-
++	> group::rw-
++	> mask::rw-
++	> other::r--
++	> 
++	$ rm -R d
++
++Handle escaped literal characters by octal code (bin)
++	$ mkdir d
++	$ touch d/f
++	$ setfacl -m u:\\142\\151\\156:rw- d/f
++	$ getfacl --omit-header d/f
++	> user::rw-
++	> user:bin:rw-
++	> group::rw-
++	> mask::rw-
++	> other::r--
++	> 
++	$ rm -R d
++
++Malformed restore file
++
++	$ echo "# owner: root" > f
++	$ setfacl --restore=f 2>&1
++	>setfacl: f: No filename found in line 0, aborting
+Index: acl/test/misc.test
+===================================================================
+--- acl.orig/test/misc.test
++++ /dev/null
+@@ -1,501 +0,0 @@
+-Pretty comprehensive ACL tests.
+- 
+-This must be run on a filesystem with ACL support. Also, you will need
+-two dummy users (bin and daemon) and a dummy group (daemon).
+- 
+-	$ rm -f f
+-	$ umask 027
+-	$ touch f
+-	  
+-Only change a base ACL:
+-	$ chacl u::rw,g::r,o::- f
+-	$ setfacl -m u::r f
+-	$ setfacl -m u::rw,u:bin:rw f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw----+
+-	
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> group::r--
+-	> mask::rw-
+-	> other::---
+-	> 
+-
+-	$ rm f
+-	$ umask 022
+-	$ touch f
+-	$ setfacl -m u:bin:rw f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw-r--+
+-
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> group::r--
+-	> mask::rw-
+-	> other::r--
+-	> 
+-
+-	$rm f
+-	$ umask 027
+-	$ mkdir d
+-	$ setfacl -m u:bin:rwx d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxrwx---+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::---
+-	> 
+-
+-	$ rmdir d
+-	$ umask 022
+-	$ mkdir d
+-	$ setfacl -m u:bin:rwx d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxrwxr-x+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	> 
+-
+-	$ rmdir d
+-	 
+-
+-Multiple users
+-	 
+-	$ umask 022
+-	$ touch f
+-	$ setfacl -m u:bin:rw,u:daemon:r f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw-r--+
+-
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> user:daemon:r--
+-	> group::r--
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	 
+-Multiple groups
+-	 
+-	$ setfacl -m g:users:rw,g:daemon:r f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw-r--+
+-
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> user:daemon:r--
+-	> group::r--
+-	> group:daemon:r--
+-	> group:users:rw-
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	 
+-Remove one group
+-	 
+-	$ setfacl -x g:users f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw-r--+
+-
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> user:daemon:r--
+-	> group::r--
+-	> group:daemon:r--
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	 
+-Remove one user
+-	 
+-	$ setfacl -x u:daemon f
+-	$ ls -dl f | awk '{print $1}'
+-	> -rw-rw-r--+
+-
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:bin:rw-
+-	> group::r--
+-	> group:daemon:r--
+-	> mask::rw-
+-	> other::r--
+-	> 
+-
+-	$ rm f
+-	 
+-Default ACL
+-	 
+-	$ umask 027
+-	$ mkdir d
+-	$ setfacl -m u:bin:rwx,u:daemon:rw,d:u:bin:rwx,d:m:rx d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxrwx---+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:rwx
+-	> user:daemon:rw-
+-	> group::r-x
+-	> mask::rwx
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-	 
+-Umask now ignored?
+- 
+-	$ umask 027
+-	$ touch d/f
+-	$ ls -dl d/f | awk '{print $1}'
+-	> -rw-r-----+
+-
+-	$ getfacl --omit-header d/f
+-	> user::rw-
+-	> user:bin:rwx	#effective:r--
+-	> group::r-x	#effective:r--
+-	> mask::r--
+-	> other::---
+-	> 
+-
+-	$ rm d/f
+-	$ umask 022
+-	$ touch d/f
+-	$ ls -dl d/f | awk '{print $1}'
+-	> -rw-r-----+
+-
+-	$ getfacl --omit-header d/f
+-	> user::rw-
+-	> user:bin:rwx	#effective:r--
+-	> group::r-x	#effective:r--
+-	> mask::r--
+-	> other::---
+-	> 
+-
+-	$ rm d/f
+-	 
+-Default ACL copying
+- 
+-	$ umask 000
+-	$ mkdir d/d
+-	$ ls -dl d/d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/d
+-	> user::rwx
+-	> user:bin:rwx	#effective:r-x
+-	> group::r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-
+-	$ rmdir d/d
+-	$ umask 022
+-	$ mkdir d/d
+-	$ ls -dl d/d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/d
+-	> user::rwx
+-	> user:bin:rwx	#effective:r-x
+-	> group::r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-	 
+-Add some users and groups
+- 
+-	$ setfacl -nm u:daemon:rx,d:u:daemon:rx,g:users:rx,g:daemon:rwx d/d
+-	$ ls -dl d/d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/d
+-	> user::rwx
+-	> user:bin:rwx	#effective:r-x
+-	> user:daemon:r-x
+-	> group::r-x
+-	> group:daemon:rwx	#effective:r-x
+-	> group:users:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:user:daemon:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-	 
+-Symlink in directory with default ACL?
+-	 
+-	$ ln -s d d/l
+-	$ ls -dl d/l | awk '{print $1}' | sed 's/\\.$//g'
+-	> lrwxrwxrwx
+-
+-	$ ls -dl -L d/l | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/l
+-	> user::rwx
+-	> user:bin:rwx	#effective:r-x
+-	> user:daemon:r-x
+-	> group::r-x
+-	> group:daemon:rwx	#effective:r-x
+-	> group:users:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:user:daemon:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-
+-	$ rm d/l
+-	 
+-Does mask manipulation work?
+-	 
+-	$ setfacl -m g:daemon:rx,u:bin:rx d/d
+-	$ ls -dl d/d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/d
+-	> user::rwx
+-	> user:bin:r-x
+-	> user:daemon:r-x
+-	> group::r-x
+-	> group:daemon:r-x
+-	> group:users:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx	#effective:r-x
+-	> default:user:daemon:r-x
+-	> default:group::r-x
+-	> default:mask::r-x
+-	> default:other::---
+-	> 
+-
+-	$ setfacl -m d:u:bin:rwx d/d
+-	$ ls -dl d/d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d/d
+-	> user::rwx
+-	> user:bin:r-x
+-	> user:daemon:r-x
+-	> group::r-x
+-	> group:daemon:r-x
+-	> group:users:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:rwx
+-	> default:user:daemon:r-x
+-	> default:group::r-x
+-	> default:mask::rwx
+-	> default:other::---
+-	> 
+-
+-	$ rmdir d/d
+-	 
+-Remove the default ACL
+-	 
+-	$ setfacl -k d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxrwx---+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:rwx
+-	> user:daemon:rw-
+-	> group::r-x
+-	> mask::rwx
+-	> other::---
+-	> 
+-	 
+-Reset to base entries
+-	 
+-	$ setfacl -b d
+-	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
+-	> drwxr-x---
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> group::r-x
+-	> other::---
+-	> 
+-	 
+-Now, chmod should change the group_obj entry
+-	 
+-	$ chmod 775 d
+-	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
+-	> drwxrwxr-x
+-	
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> group::rwx
+-	> other::r-x
+-	> 
+-
+-	$ rmdir d
+-	$ umask 002
+-	$ mkdir d
+-	$ setfacl -m u:daemon:rwx,u:bin:rx,d:u:daemon:rwx,d:u:bin:rx d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxrwxr-x+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:r-x
+-	> user:daemon:rwx
+-	> group::rwx
+-	> mask::rwx
+-	> other::r-x
+-	> default:user::rwx
+-	> default:user:bin:r-x
+-	> default:user:daemon:rwx
+-	> default:group::rwx
+-	> default:mask::rwx
+-	> default:other::r-x
+-	> 
+-
+-	$ chmod 750 d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:r-x
+-	> user:daemon:rwx	#effective:r-x
+-	> group::rwx	#effective:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:r-x
+-	> default:user:daemon:rwx
+-	> default:group::rwx
+-	> default:mask::rwx
+-	> default:other::r-x
+-	> 
+-
+-	$ chmod 750 d
+-	$ ls -dl d | awk '{print $1}'
+-	> drwxr-x---+
+-
+-	$ getfacl --omit-header d
+-	> user::rwx
+-	> user:bin:r-x
+-	> user:daemon:rwx	#effective:r-x
+-	> group::rwx	#effective:r-x
+-	> mask::r-x
+-	> other::---
+-	> default:user::rwx
+-	> default:user:bin:r-x
+-	> default:user:daemon:rwx
+-	> default:group::rwx
+-	> default:mask::rwx
+-	> default:other::r-x
+-	> 
+-
+-	$ rmdir d
+-
+-Dangling symlink test https://savannah.nongnu.org/bugs/?28131
+-
+-	$ mkdir d
+-	$ ln -s d/a d/b
+-	$ getfacl -R d
+-	> # file: d
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> group::rwx
+-	> other::r-x
+-	> 
+-	$ setfacl -R -m u:bin:rw d
+-	$ getfacl -RL d
+-	> getfacl: d/b: No such file or directory
+-	> # file: d
+-	> # owner: %TUSER
+-	> # group: %TGROUP
+-	> user::rwx
+-	> user:bin:rw-
+-	> group::rwx
+-	> mask::rwx
+-	> other::r-x
+-	> 
+-	$ setfacl -RL -m u:bin:rw d
+-	> setfacl: d/b: No such file or directory
+-	$ rm -R d
+-
+-Handle escaped literal backslash followed by numeric username
+-	$ mkdir d
+-	$ touch d/f
+-	$ setfacl -m u:domain\\\\12345:rw- d/f
+-	$ getfacl --omit-header d/f
+-	> user::rw-
+-	> user:domain\\12345:rw-
+-	> group::rw-
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	$ rm -R d
+-
+-Handle escaped literal backslash
+-	$ mkdir d
+-	$ touch d/f
+-	$ setfacl -m u:domain\\\\user:rw- d/f
+-	$ getfacl --omit-header d/f
+-	> user::rw-
+-	> user:domain\\user:rw-
+-	> group::rw-
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	$ rm -R d
+-
+-Handle escaped literal characters by octal code (bin)
+-	$ mkdir d
+-	$ touch d/f
+-	$ setfacl -m u:\\142\\151\\156:rw- d/f
+-	$ getfacl --omit-header d/f
+-	> user::rw-
+-	> user:bin:rw-
+-	> group::rw-
+-	> mask::rw-
+-	> other::r--
+-	> 
+-	$ rm -R d
+-
+-Malformed restore file
+-
+-	$ echo "# owner: root" > f
+-	$ setfacl --restore=f 2>&1
+-	>setfacl: f: No filename found in line 0, aborting
+Index: acl/test/nfs/nfs-dir.run
+===================================================================
+--- /dev/null
++++ acl/test/nfs/nfs-dir.run
+@@ -0,0 +1,50 @@
++This is a regression test for a bug in 2.4 kernels. The test must be run
++as root on a machine that has a loopback mounted NFS export. The mount
++must have root squashing enabled. The test must be run in the root of
++the nfs mount, and requires the following environment variable:
++
++EXPORT_PATH => the path that is mounted at the working directory.
++
++	Create a test directory and file.
++
++	$ umask 022
++	$ mkdir %{EXPORT_PATH}/test
++	$ echo blah > %{EXPORT_PATH}/test/blah
++
++	Make sure the file can be accessed before.
++
++	$ su bin
++	$ cat test/blah
++	> blah
++
++	Set up a situation that triggers the bug.
++
++	$ su
++	$ chmod go-rwx %{EXPORT_PATH}/test
++	$ setfacl -m u:bin:rx %{EXPORT_PATH}/test
++	$ ls -dl %{EXPORT_PATH}/test | awk '{print $1, $3, $4}'
++	> drwxr-x---+ root root
++	$ getfacl --omit-header %{EXPORT_PATH}/test 2> /dev/null
++	> user::rwx
++	> user:bin:r-x
++	> group::---
++	> mask::r-x
++	> other::---
++	>
++
++	This should also succeed. With the bug, reading the file would
++	fail with "Stale NFS file handle" or "Input/output error".
++
++	$ su bin
++	$ cat test/blah
++	> blah
++	$ sleep 3
++	$ cat test/blah
++	> blah
++	$ cat test/blah
++	> blah
++
++	Clean up.
++
++	$ su
++	$ rm -rf %{EXPORT_PATH}/test
+Index: acl/test/nfs/nfs-dir.test
+===================================================================
+--- acl.orig/test/nfs/nfs-dir.test
++++ /dev/null
+@@ -1,50 +0,0 @@
+-This is a regression test for a bug in 2.4 kernels. The test must be run
+-as root on a machine that has a loopback mounted NFS export. The mount
+-must have root squashing enabled. The test must be run in the root of
+-the nfs mount, and requires the following environment variable:
+-
+-EXPORT_PATH => the path that is mounted at the working directory.
+-
+-	Create a test directory and file.
+-
+-	$ umask 022
+-	$ mkdir %{EXPORT_PATH}/test
+-	$ echo blah > %{EXPORT_PATH}/test/blah
+-
+-	Make sure the file can be accessed before.
+-
+-	$ su bin
+-	$ cat test/blah
+-	> blah
+-
+-	Set up a situation that triggers the bug.
+-
+-	$ su
+-	$ chmod go-rwx %{EXPORT_PATH}/test
+-	$ setfacl -m u:bin:rx %{EXPORT_PATH}/test
+-	$ ls -dl %{EXPORT_PATH}/test | awk '{print $1, $3, $4}'
+-	> drwxr-x---+ root root
+-	$ getfacl --omit-header %{EXPORT_PATH}/test 2> /dev/null
+-	> user::rwx
+-	> user:bin:r-x
+-	> group::---
+-	> mask::r-x
+-	> other::---
+-	>
+-
+-	This should also succeed. With the bug, reading the file would
+-	fail with "Stale NFS file handle" or "Input/output error".
+-
+-	$ su bin
+-	$ cat test/blah
+-	> blah
+-	$ sleep 3
+-	$ cat test/blah
+-	> blah
+-	$ cat test/blah
+-	> blah
+-
+-	Clean up.
+-
+-	$ su
+-	$ rm -rf %{EXPORT_PATH}/test
+Index: acl/test/nfs/nfsacl.run
+===================================================================
+--- /dev/null
++++ acl/test/nfs/nfsacl.run
+@@ -0,0 +1,42 @@
++This is a regression test for bugs in the nfsacl protocol extension.
++The test should be run on an NFS export mount with ACL support.
++
++	Create a test directory and file.
++
++	$ umask 022
++	$ mkdir -p test/sub
++	$ echo blah > test/sub/blah
++
++	$ cp -rp test/sub test/sub2
++	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
++	> drwxr-xr-x test/sub2
++	> -rw-r--r-- test/sub2/blah
++
++	$ rm -rf test/sub2
++
++	$ setfacl -m u:daemon:rwx test/sub
++	$ setfacl -dm u:daemon:rwx test/sub
++	$ getfattr -m- test/sub
++	> # file: test/sub
++	> system.posix_acl_access
++	> system.posix_acl_default
++	>
++
++	$ cp -rp test/sub test/sub2
++	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
++	> drwxrwxr-x+ test/sub2
++	> -rw-r--r-- test/sub2/blah
++
++	$ rm -rf test/sub2
++
++	$ setfacl -m u:daemon:rw test/sub/blah
++	$ cp -rp test/sub test/sub2
++	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
++	> drwxrwxr-x+ test/sub2
++	> -rw-rw-r--+ test/sub2/blah
++
++	$ rm -rf test/sub2
++
++	Clean up.
++
++	$ rm -rf test
+Index: acl/test/nfs/nfsacl.test
+===================================================================
+--- acl.orig/test/nfs/nfsacl.test
++++ /dev/null
+@@ -1,42 +0,0 @@
+-This is a regression test for bugs in the nfsacl protocol extension.
+-The test should be run on an NFS export mount with ACL support.
+-
+-	Create a test directory and file.
+-
+-	$ umask 022
+-	$ mkdir -p test/sub
+-	$ echo blah > test/sub/blah
+-
+-	$ cp -rp test/sub test/sub2
+-	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
+-	> drwxr-xr-x test/sub2
+-	> -rw-r--r-- test/sub2/blah
+-
+-	$ rm -rf test/sub2
+-
+-	$ setfacl -m u:daemon:rwx test/sub
+-	$ setfacl -dm u:daemon:rwx test/sub
+-	$ getfattr -m- test/sub
+-	> # file: test/sub
+-	> system.posix_acl_access
+-	> system.posix_acl_default
+-	>
+-
+-	$ cp -rp test/sub test/sub2
+-	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
+-	> drwxrwxr-x+ test/sub2
+-	> -rw-r--r-- test/sub2/blah
+-
+-	$ rm -rf test/sub2
+-
+-	$ setfacl -m u:daemon:rw test/sub/blah
+-	$ cp -rp test/sub test/sub2
+-	$ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
+-	> drwxrwxr-x+ test/sub2
+-	> -rw-rw-r--+ test/sub2/blah
+-
+-	$ rm -rf test/sub2
+-
+-	Clean up.
+-
+-	$ rm -rf test
+Index: acl/test/root/getfacl.run
+===================================================================
+--- /dev/null
++++ acl/test/root/getfacl.run
+@@ -0,0 +1,19 @@
++Make sure that getfacl always adds at least one space between the permissions
++in an acl entry and the effective permissions comment.
++
++Cry immediately if we are not running as root.
++
++	$ require_root
++
++	$ umask 022
++	$ mkdir d
++	$ setfacl -dm group:loooooooooooooooooooooooonggroup:rwx d
++	$ getfacl -cde d
++	> user::rwx
++	> group::r-x	#effective:r-x
++	> group:loooooooooooooooooooooooonggroup:rwx	#effective:rwx
++	> mask::rwx
++	> other::r-x
++	>
++
++	$ rm -r d
+Index: acl/test/root/getfacl.test
+===================================================================
+--- acl.orig/test/root/getfacl.test
++++ /dev/null
+@@ -1,19 +0,0 @@
+-Make sure that getfacl always adds at least one space between the permissions
+-in an acl entry and the effective permissions comment.
+-
+-Cry immediately if we are not running as root.
+-
+-	$ require_root
+-
+-	$ umask 022
+-	$ mkdir d
+-	$ setfacl -dm group:loooooooooooooooooooooooonggroup:rwx d
+-	$ getfacl -cde d
+-	> user::rwx
+-	> group::r-x	#effective:r-x
+-	> group:loooooooooooooooooooooooonggroup:rwx	#effective:rwx
+-	> mask::rwx
+-	> other::r-x
+-	>
+-
+-	$ rm -r d
+Index: acl/test/root/permissions.run
+===================================================================
+--- /dev/null
++++ acl/test/root/permissions.run
+@@ -0,0 +1,279 @@
++This script tests if file permissions are properly checked with and
++without ACLs. The script must be run as root to allow switching users.
++The following users are required. They must be a member in the groups
++listed in parentheses.
++
++	bin (bin)
++	daemon (bin, daemon)
++
++
++Cry immediately if we are not running as root.
++
++	$ require_root
++
++
++First, set up a temporary directory and create a regular file with
++defined permissions.
++
++	$ umask 022
++	$ mkdir d
++	$ cd d
++	$ umask 027
++	$ touch f
++	$ ls -l f | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
++	> -rw-r----- root root
++
++
++Make sure root has access to the file.  Verify that user daemon does not
++have access to the file owned by root.
++
++	$ echo root > f
++
++	$ su daemon
++	$ echo daemon >> f
++	>~ .*f: Permission denied$
++
++	$ su
++
++
++Now, change the ownership of the file to bin:bin and verify that this
++gives user bin write access.
++
++	$ chown bin:bin f
++	$ ls -l f | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
++	> -rw-r----- bin bin
++	$ su bin
++	$ echo bin >> f
++
++
++User daemon is a member in the owning group, which has only read access.
++Verify this.
++
++	$ su daemon
++	$ cat f
++	> root
++	> bin
++
++	$ echo daemon >> f
++	>~ .*f: Permission denied$
++
++
++Now, add an ACL entry for user daemon that grants him rw- access. File
++owners and users capable of CAP_FOWNER are allowed to change ACLs.
++
++	$ su bin
++	$ setfacl -m u:daemon:rw f
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:daemon:rw-
++	> group::r--
++	> mask::rw-
++	> other::---
++	>
++
++
++Verify that the additional ACL entry grants user daemon write access.
++
++	$ su daemon
++	$ echo daemon >> f
++	$ cat f
++	> root
++	> bin
++	> daemon
++
++
++Remove write access from the group class permission bits, and
++verify that this masks daemon's write permission.
++
++	$ su bin
++	$ chmod g-w f
++	$ getfacl --omit-header f
++	> user::rw-
++	> user:daemon:rw-	#effective:r--
++	> group::r--
++	> mask::r--
++	> other::---
++	>
++
++	$ su daemon
++	$ echo daemon >> f
++	>~ .*f: Permission denied$
++
++
++Add an entry for group daemon with rw- access, and change the
++permissions for user daemon to r--. Also change the others permissions t
++rw-. The user entry should take precedence, so daemon should be denied
++access.
++
++	$ su bin
++	$ setfacl -m u:daemon:r,g:daemon:rw-,o::rw- f
++
++	$ su daemon
++	$ echo daemon >> f
++	>~ .*f: Permission denied$
++
++
++Remove the entry for user daemon. The group daemon permissions should
++now give user daemon rw- access.
++
++	$ su bin
++	$ setfacl -x u:daemon f
++
++	$ su daemon
++	$ echo daemon2 >> f
++	$ cat f
++	> root
++	> bin
++	> daemon
++	> daemon2
++
++
++Set the group daemon permissions to r-- and verify that after than, user
++daemon does not have write access anymore.
++
++	$ su bin
++	$ setfacl -m g:daemon:r f
++
++	$ su daemon
++	$ echo daemon3 >> f
++	>~ .*f: Permission denied$
++
++
++Now, remove the group daemon entry. Because user daemon is a member in
++the owning group, he should still have no write access.
++
++	$ su bin
++	$ setfacl -x g:daemon f
++
++	$ su daemon
++	$ echo daemon4 >> f
++	>~ .*f: Permission denied$
++
++
++Change the owning group. The other permissions should now grant user
++daemon write access.
++
++	$ su
++	$ chgrp root f
++
++	$ su daemon
++	$ echo daemon5 >> f
++	$ cat f
++	> root
++	> bin
++	> daemon
++	> daemon2
++	> daemon5
++
++
++Verify that permissions in separate matching ACL entries do not
++accumulate.
++
++	$ su
++	$ setfacl -m g:bin:r,g:daemon:w f
++
++	$ su daemon
++	$ : < f
++	$ : > f
++	$ : <> f
++	>~ .*f: Permission denied$
++
++
++Test if directories can have ACLs.  We assume that only one access check
++algorithm is used for all file types the file system, so these tests
++only need to verify that ACL permissions make a difference.
++
++	$ su
++	$ mkdir -m 750 e
++	$ touch e/h
++
++	$ su bin
++	$ shopt -s nullglob ; echo e/*
++	>
++
++	$ echo i > e/i
++	>~ .*e/i: Permission denied$
++
++	$ su
++	$ setfacl -m u:bin:rx e
++
++	$ su bin
++	$ echo e/*
++	> e/h
++	$ echo i > e/i
++	>~ .*e/i: Permission denied$
++
++	$ su
++	$ setfacl -m u:bin:rwx e
++
++	$ su bin
++	$ echo i > e/i
++
++
++Test if symlinks are properly followed.
++
++	$ su
++	$ touch g
++	$ ln -s g l
++	$ setfacl -m u:bin:rw l
++	$ ls -l g | awk -- '{ print $1, $3, $4 }'
++	> -rw-rw----+ root root
++
++
++Test if ACLs are effective for block and character special files, fifos,
++sockets. This is done by creating special files locally. The devices do
++not need to exist: The access check is earlier in the code path than the
++test if the device exists.
++
++
++	$ mknod -m 0660 hdt b 91 64
++	$ mknod -m 0660 null c 1 3
++	$ mkfifo -m 0660 fifo
++
++	$ su bin
++	$ : < hdt
++	>~ .*hdt: Permission denied$
++	$ : < null
++	>~ .*null: Permission denied$
++	$ : < fifo
++	>~ .*fifo: Permission denied$
++
++	$ su
++	$ setfacl -m u:bin:rw hdt null fifo
++
++	$ su bin
++	$ : < hdt
++	>~ .*hdt: No such device or address$
++	$ : < null
++	$ ( echo blah > fifo & ) ; cat fifo
++	> blah
++
++
++Test if CAP_FOWNER is properly honored for directories. This addresses a
++specific bug in XFS 1.2, which does not grant root access to files in
++directories if the file has an ACL and only CAP_FOWNER would grant them.
++
++	$ su
++	$ mkdir -m 600 x
++	$ chown daemon:daemon x
++	$ echo j > x/j
++	$ ls -l x/j | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
++	> -rw-r----- root root
++
++	$ setfacl -m u:daemon:r x
++
++	$ ls -l x/j | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
++	> -rw-r----- root root
++	(With the bug this gives: `ls: x/j: Permission denied'.)
++
++	$ echo k > x/k
++	(With the bug this gives: `x/k: Permission denied'.)
++
++	$ chmod 750 x
++
++
++Clean up.
++
++	$ su
++	$ cd ..
++	$ rm -rf d
+Index: acl/test/root/permissions.test
+===================================================================
+--- acl.orig/test/root/permissions.test
++++ /dev/null
+@@ -1,279 +0,0 @@
+-This script tests if file permissions are properly checked with and
+-without ACLs. The script must be run as root to allow switching users.
+-The following users are required. They must be a member in the groups
+-listed in parentheses.
+-
+-	bin (bin)
+-	daemon (bin, daemon)
+-
+-
+-Cry immediately if we are not running as root.
+-
+-	$ require_root
+-
+-
+-First, set up a temporary directory and create a regular file with
+-defined permissions.
+-
+-	$ umask 022
+-	$ mkdir d
+-	$ cd d
+-	$ umask 027
+-	$ touch f
+-	$ ls -l f | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
+-	> -rw-r----- root root
+-
+-
+-Make sure root has access to the file.  Verify that user daemon does not
+-have access to the file owned by root.
+-
+-	$ echo root > f
+-
+-	$ su daemon
+-	$ echo daemon >> f
+-	>~ .*f: Permission denied$
+-
+-	$ su
+-
+-
+-Now, change the ownership of the file to bin:bin and verify that this
+-gives user bin write access.
+-
+-	$ chown bin:bin f
+-	$ ls -l f | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
+-	> -rw-r----- bin bin
+-	$ su bin
+-	$ echo bin >> f
+-
+-
+-User daemon is a member in the owning group, which has only read access.
+-Verify this.
+-
+-	$ su daemon
+-	$ cat f
+-	> root
+-	> bin
+-
+-	$ echo daemon >> f
+-	>~ .*f: Permission denied$
+-
+-
+-Now, add an ACL entry for user daemon that grants him rw- access. File
+-owners and users capable of CAP_FOWNER are allowed to change ACLs.
+-
+-	$ su bin
+-	$ setfacl -m u:daemon:rw f
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:daemon:rw-
+-	> group::r--
+-	> mask::rw-
+-	> other::---
+-	>
+-
+-
+-Verify that the additional ACL entry grants user daemon write access.
+-
+-	$ su daemon
+-	$ echo daemon >> f
+-	$ cat f
+-	> root
+-	> bin
+-	> daemon
+-
+-
+-Remove write access from the group class permission bits, and
+-verify that this masks daemon's write permission.
+-
+-	$ su bin
+-	$ chmod g-w f
+-	$ getfacl --omit-header f
+-	> user::rw-
+-	> user:daemon:rw-	#effective:r--
+-	> group::r--
+-	> mask::r--
+-	> other::---
+-	>
+-
+-	$ su daemon
+-	$ echo daemon >> f
+-	>~ .*f: Permission denied$
+-
+-
+-Add an entry for group daemon with rw- access, and change the
+-permissions for user daemon to r--. Also change the others permissions t
+-rw-. The user entry should take precedence, so daemon should be denied
+-access.
+-
+-	$ su bin
+-	$ setfacl -m u:daemon:r,g:daemon:rw-,o::rw- f
+-
+-	$ su daemon
+-	$ echo daemon >> f
+-	>~ .*f: Permission denied$
+-
+-
+-Remove the entry for user daemon. The group daemon permissions should
+-now give user daemon rw- access.
+-
+-	$ su bin
+-	$ setfacl -x u:daemon f
+-
+-	$ su daemon
+-	$ echo daemon2 >> f
+-	$ cat f
+-	> root
+-	> bin
+-	> daemon
+-	> daemon2
+-
+-
+-Set the group daemon permissions to r-- and verify that after than, user
+-daemon does not have write access anymore.
+-
+-	$ su bin
+-	$ setfacl -m g:daemon:r f
+-
+-	$ su daemon
+-	$ echo daemon3 >> f
+-	>~ .*f: Permission denied$
+-
+-
+-Now, remove the group daemon entry. Because user daemon is a member in
+-the owning group, he should still have no write access.
+-
+-	$ su bin
+-	$ setfacl -x g:daemon f
+-
+-	$ su daemon
+-	$ echo daemon4 >> f
+-	>~ .*f: Permission denied$
+-
+-
+-Change the owning group. The other permissions should now grant user
+-daemon write access.
+-
+-	$ su
+-	$ chgrp root f
+-
+-	$ su daemon
+-	$ echo daemon5 >> f
+-	$ cat f
+-	> root
+-	> bin
+-	> daemon
+-	> daemon2
+-	> daemon5
+-
+-
+-Verify that permissions in separate matching ACL entries do not
+-accumulate.
+-
+-	$ su
+-	$ setfacl -m g:bin:r,g:daemon:w f
+-
+-	$ su daemon
+-	$ : < f
+-	$ : > f
+-	$ : <> f
+-	>~ .*f: Permission denied$
+-
+-
+-Test if directories can have ACLs.  We assume that only one access check
+-algorithm is used for all file types the file system, so these tests
+-only need to verify that ACL permissions make a difference.
+-
+-	$ su
+-	$ mkdir -m 750 e
+-	$ touch e/h
+-
+-	$ su bin
+-	$ shopt -s nullglob ; echo e/*
+-	>
+-
+-	$ echo i > e/i
+-	>~ .*e/i: Permission denied$
+-
+-	$ su
+-	$ setfacl -m u:bin:rx e
+-
+-	$ su bin
+-	$ echo e/*
+-	> e/h
+-	$ echo i > e/i
+-	>~ .*e/i: Permission denied$
+-
+-	$ su
+-	$ setfacl -m u:bin:rwx e
+-
+-	$ su bin
+-	$ echo i > e/i
+-
+-
+-Test if symlinks are properly followed.
+-
+-	$ su
+-	$ touch g
+-	$ ln -s g l
+-	$ setfacl -m u:bin:rw l
+-	$ ls -l g | awk -- '{ print $1, $3, $4 }'
+-	> -rw-rw----+ root root
+-
+-
+-Test if ACLs are effective for block and character special files, fifos,
+-sockets. This is done by creating special files locally. The devices do
+-not need to exist: The access check is earlier in the code path than the
+-test if the device exists.
+-
+-
+-	$ mknod -m 0660 hdt b 91 64
+-	$ mknod -m 0660 null c 1 3
+-	$ mkfifo -m 0660 fifo
+-
+-	$ su bin
+-	$ : < hdt
+-	>~ .*hdt: Permission denied$
+-	$ : < null
+-	>~ .*null: Permission denied$
+-	$ : < fifo
+-	>~ .*fifo: Permission denied$
+-
+-	$ su
+-	$ setfacl -m u:bin:rw hdt null fifo
+-
+-	$ su bin
+-	$ : < hdt
+-	>~ .*hdt: No such device or address$
+-	$ : < null
+-	$ ( echo blah > fifo & ) ; cat fifo
+-	> blah
+-
+-
+-Test if CAP_FOWNER is properly honored for directories. This addresses a
+-specific bug in XFS 1.2, which does not grant root access to files in
+-directories if the file has an ACL and only CAP_FOWNER would grant them.
+-
+-	$ su
+-	$ mkdir -m 600 x
+-	$ chown daemon:daemon x
+-	$ echo j > x/j
+-	$ ls -l x/j | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
+-	> -rw-r----- root root
+-
+-	$ setfacl -m u:daemon:r x
+-
+-	$ ls -l x/j | awk -- '{ print $1, $3, $4 }' | sed 's/\\.//g'
+-	> -rw-r----- root root
+-	(With the bug this gives: `ls: x/j: Permission denied'.)
+-
+-	$ echo k > x/k
+-	(With the bug this gives: `x/k: Permission denied'.)
+-
+-	$ chmod 750 x
+-
+-
+-Clean up.
+-
+-	$ su
+-	$ cd ..
+-	$ rm -rf d
+Index: acl/test/root/restore.run
+===================================================================
+--- /dev/null
++++ acl/test/root/restore.run
+@@ -0,0 +1,27 @@
++Ensure setuid bit is restored when the owner changes
++ https://bugzilla.redhat.com/show_bug.cgi?id=467936#c7
++
++Cry immediately if we are not running as root.
++
++	$ require_root
++
++	$ touch passwd
++	$ chmod 755 passwd
++	$ chmod u+s passwd
++	$ getfacl passwd > passwd.acl
++	$ cat passwd.acl
++	> # file: passwd
++	> # owner: root
++	> # group: root
++	> # flags: s--
++	> user::rwx
++	> group::r-x
++	> other::r-x
++	>
++	$ chown bin passwd
++	$ chmod u+s passwd
++	$ setfacl --restore passwd.acl
++	$ ls -dl passwd | awk '{print $1 " " $3 " " $4}' | sed 's/\\.//g'
++	> -rwsr-xr-x root root
++
++	$ rm passwd passwd.acl
+Index: acl/test/root/restore.test
+===================================================================
+--- acl.orig/test/root/restore.test
++++ /dev/null
+@@ -1,27 +0,0 @@
+-Ensure setuid bit is restored when the owner changes
+- https://bugzilla.redhat.com/show_bug.cgi?id=467936#c7
+-
+-Cry immediately if we are not running as root.
+-
+-	$ require_root
+-
+-	$ touch passwd
+-	$ chmod 755 passwd
+-	$ chmod u+s passwd
+-	$ getfacl passwd > passwd.acl
+-	$ cat passwd.acl
+-	> # file: passwd
+-	> # owner: root
+-	> # group: root
+-	> # flags: s--
+-	> user::rwx
+-	> group::r-x
+-	> other::r-x
+-	>
+-	$ chown bin passwd
+-	$ chmod u+s passwd
+-	$ setfacl --restore passwd.acl
+-	$ ls -dl passwd | awk '{print $1 " " $3 " " $4}' | sed 's/\\.//g'
+-	> -rwsr-xr-x root root
+-
+-	$ rm passwd passwd.acl
+Index: acl/test/root/setfacl.run
+===================================================================
+--- /dev/null
++++ acl/test/root/setfacl.run
+@@ -0,0 +1,148 @@
++Setfacl utility tests. Run these tests on a filesystem with ACL support.
++
++Cry immediately if we are not running as root.
++
++	$ require_root
++
++ 	$ mkdir d
++	$ chown bin:bin d
++	$ cd d
++
++	$ su bin
++	$ sg bin
++	$ umask 027
++	$ touch g
++	$ ls -dl g | awk '{print $1}' | sed 's/\\.//g'
++	> -rw-r-----
++
++	$ setfacl -m m:- g
++	$ ls -dl g | awk '{print $1}'
++	> -rw-------+
++
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rw-
++	> group::r--	#effective:---
++	> mask::---
++	> other::---
++	>
++
++	$ setfacl -x m g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rw-
++	> group::r--
++	> other::---
++	>
++
++	$ setfacl -m u:daemon:rw g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rw-
++	> user:daemon:rw-
++	> group::r--
++	> mask::rw-
++	> other::---
++	>
++
++	$ setfacl -m u::rwx,g::r-x,o:- g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rwx
++	> user:daemon:rw-
++	> group::r-x
++	> mask::rwx
++	> other::---
++	>
++
++	$ setfacl -m u::rwx,g::r-x,o:-,m:- g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rwx
++	> user:daemon:rw-	#effective:---
++	> group::r-x	#effective:---
++	> mask::---
++	> other::---
++	>
++
++	$ setfacl -m u::rwx,g::r-x,o:-,u:root:-,m:- g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rwx
++	> user:root:---
++	> user:daemon:rw-	#effective:---
++	> group::r-x	#effective:---
++	> mask::---
++	> other::---
++	>
++
++	$ setfacl -m u::rwx,g::r-x,o:-,u:root:-,m:- g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rwx
++	> user:root:---
++	> user:daemon:rw-	#effective:---
++	> group::r-x	#effective:---
++	> mask::---
++	> other::---
++	>
++
++	$ setfacl -m u::rwx,g::r-x,o:-,u:root:- g
++	$ getfacl g
++	> # file: g
++	> # owner: bin
++	> # group: bin
++	> user::rwx
++	> user:root:---
++	> user:daemon:rw-
++	> group::r-x
++	> mask::rwx
++	> other::---
++	>
++
++	$ setfacl --test -x u: g
++	> setfacl: g: Malformed access ACL `user:root:---,user:daemon:rw-,group::r-x,mask::rwx,other::---': Missing or wrong entry at entry 1
++
++	$ setfacl --test -x u:x
++	> setfacl: Option -x: Invalid argument near character 3
++
++	$ setfacl -m d:u:root:rwx g
++	> setfacl: g: Only directories can have default ACLs
++
++	$ setfacl -x m g
++	> setfacl: g: Malformed access ACL `user::rwx,user:root:---,user:daemon:rw-,group::r-x,other::---': Missing or wrong entry at entry 5
++	 setfacl --test -m d:u:daemon:rwx setfacl
++	 setfacl --test -n -m d:u:daemon:rwx setfacl
++
++Check if the mask is properly recalculated
++
++	$ mkdir d
++	$ setfacl --test -m u::rwx,u:bin:rwx,g::r-x,o::--- d
++	> d: u::rwx,u:bin:rwx,g::r-x,m::rwx,o::---,*
++
++	$ setfacl --test -m u::rwx,u:bin:rwx,g::r-x,m::---,o::--- d
++	> d: u::rwx,u:bin:rwx,g::r-x,m::---,o::---,*
++
++	$ setfacl --test -d -m u::rwx,u:bin:rwx,g::r-x,o::--- d
++	> d: *,d:u::rwx,d:u:bin:rwx,d:g::r-x,d:m::rwx,d:o::---
++
++	$ setfacl --test -d -m u::rwx,u:bin:rwx,g::r-x,m::---,o::--- d
++	> d: *,d:u::rwx,d:u:bin:rwx,d:g::r-x,d:m::---,d:o::---
++
++	$ su
++	$ cd ..
++	$ rm -r d
+Index: acl/test/root/setfacl.test
+===================================================================
+--- acl.orig/test/root/setfacl.test
++++ /dev/null
+@@ -1,148 +0,0 @@
+-Setfacl utility tests. Run these tests on a filesystem with ACL support.
+-
+-Cry immediately if we are not running as root.
+-
+-	$ require_root
+-
+- 	$ mkdir d
+-	$ chown bin:bin d
+-	$ cd d
+-
+-	$ su bin
+-	$ sg bin
+-	$ umask 027
+-	$ touch g
+-	$ ls -dl g | awk '{print $1}' | sed 's/\\.//g'
+-	> -rw-r-----
+-
+-	$ setfacl -m m:- g
+-	$ ls -dl g | awk '{print $1}'
+-	> -rw-------+
+-
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rw-
+-	> group::r--	#effective:---
+-	> mask::---
+-	> other::---
+-	>
+-
+-	$ setfacl -x m g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rw-
+-	> group::r--
+-	> other::---
+-	>
+-
+-	$ setfacl -m u:daemon:rw g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rw-
+-	> user:daemon:rw-
+-	> group::r--
+-	> mask::rw-
+-	> other::---
+-	>
+-
+-	$ setfacl -m u::rwx,g::r-x,o:- g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rwx
+-	> user:daemon:rw-
+-	> group::r-x
+-	> mask::rwx
+-	> other::---
+-	>
+-
+-	$ setfacl -m u::rwx,g::r-x,o:-,m:- g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rwx
+-	> user:daemon:rw-	#effective:---
+-	> group::r-x	#effective:---
+-	> mask::---
+-	> other::---
+-	>
+-
+-	$ setfacl -m u::rwx,g::r-x,o:-,u:root:-,m:- g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rwx
+-	> user:root:---
+-	> user:daemon:rw-	#effective:---
+-	> group::r-x	#effective:---
+-	> mask::---
+-	> other::---
+-	>
+-
+-	$ setfacl -m u::rwx,g::r-x,o:-,u:root:-,m:- g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rwx
+-	> user:root:---
+-	> user:daemon:rw-	#effective:---
+-	> group::r-x	#effective:---
+-	> mask::---
+-	> other::---
+-	>
+-
+-	$ setfacl -m u::rwx,g::r-x,o:-,u:root:- g
+-	$ getfacl g
+-	> # file: g
+-	> # owner: bin
+-	> # group: bin
+-	> user::rwx
+-	> user:root:---
+-	> user:daemon:rw-
+-	> group::r-x
+-	> mask::rwx
+-	> other::---
+-	>
+-
+-	$ setfacl --test -x u: g
+-	> setfacl: g: Malformed access ACL `user:root:---,user:daemon:rw-,group::r-x,mask::rwx,other::---': Missing or wrong entry at entry 1
+-
+-	$ setfacl --test -x u:x
+-	> setfacl: Option -x: Invalid argument near character 3
+-
+-	$ setfacl -m d:u:root:rwx g
+-	> setfacl: g: Only directories can have default ACLs
+-
+-	$ setfacl -x m g
+-	> setfacl: g: Malformed access ACL `user::rwx,user:root:---,user:daemon:rw-,group::r-x,other::---': Missing or wrong entry at entry 5
+-	 setfacl --test -m d:u:daemon:rwx setfacl
+-	 setfacl --test -n -m d:u:daemon:rwx setfacl
+-
+-Check if the mask is properly recalculated
+-
+-	$ mkdir d
+-	$ setfacl --test -m u::rwx,u:bin:rwx,g::r-x,o::--- d
+-	> d: u::rwx,u:bin:rwx,g::r-x,m::rwx,o::---,*
+-
+-	$ setfacl --test -m u::rwx,u:bin:rwx,g::r-x,m::---,o::--- d
+-	> d: u::rwx,u:bin:rwx,g::r-x,m::---,o::---,*
+-
+-	$ setfacl --test -d -m u::rwx,u:bin:rwx,g::r-x,o::--- d
+-	> d: *,d:u::rwx,d:u:bin:rwx,d:g::r-x,d:m::rwx,d:o::---
+-
+-	$ setfacl --test -d -m u::rwx,u:bin:rwx,g::r-x,m::---,o::--- d
+-	> d: *,d:u::rwx,d:u:bin:rwx,d:g::r-x,d:m::---,d:o::---
+-
+-	$ su
+-	$ cd ..
+-	$ rm -r d
+Index: acl/test/sbits-restore.run
+===================================================================
+--- /dev/null
++++ acl/test/sbits-restore.run
+@@ -0,0 +1,22 @@
++Ensure setting of SUID/SGID/sticky via --restore works
++
++	$ umask 022
++	$ mkdir d
++	$ touch d/g
++	$ touch d/u
++	$ chmod u+s d/u
++	$ chmod g+s d/g
++	$ chmod +t d
++	$ getfacl -R d > d.acl
++	$ rm -R d
++	$ mkdir d
++	$ touch d/g
++	$ touch d/u
++	$ setfacl --restore d.acl
++	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
++	> drwxr-xr-t
++	$ ls -dl d/u | awk '{print $1}' | sed 's/\\.$//g'
++	> -rwSr--r--
++	$ ls -dl d/g | awk '{print $1}' | sed 's/\\.$//g'
++	> -rw-r-Sr--
++	$ rm -Rf d
+Index: acl/test/sbits-restore.test
+===================================================================
+--- acl.orig/test/sbits-restore.test
++++ /dev/null
+@@ -1,22 +0,0 @@
+-Ensure setting of SUID/SGID/sticky via --restore works
+-
+-	$ umask 022
+-	$ mkdir d
+-	$ touch d/g
+-	$ touch d/u
+-	$ chmod u+s d/u
+-	$ chmod g+s d/g
+-	$ chmod +t d
+-	$ getfacl -R d > d.acl
+-	$ rm -R d
+-	$ mkdir d
+-	$ touch d/g
+-	$ touch d/u
+-	$ setfacl --restore d.acl
+-	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
+-	> drwxr-xr-t
+-	$ ls -dl d/u | awk '{print $1}' | sed 's/\\.$//g'
+-	> -rwSr--r--
+-	$ ls -dl d/g | awk '{print $1}' | sed 's/\\.$//g'
+-	> -rw-r-Sr--
+-	$ rm -Rf d
+Index: acl/test/setfacl-X.run
+===================================================================
+--- /dev/null
++++ acl/test/setfacl-X.run
+@@ -0,0 +1,119 @@
++	$ umask 022
++	$ mkdir d
++	$ cd d
++
++	$ setfacl -dm u:bin:rwx .
++
++	$ touch f g
++	$ chmod ugo+x f
++	$ setfacl -m u:bin:rw,g::r g
++	$ setfacl -m u:root:rwX f g
++	$ getfacl --omit-header --no-effective f g
++	> user::rwx
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	>
++	> user::rw-
++	> user:root:rw-
++	> user:bin:rw-
++	> group::r--
++	> mask::rw-
++	> other::r--
++	>
++
++	$ rm f g
++	$ touch f g
++	$ mkdir d e
++	$ setfacl -n -m u:root:rwX d f e g
++	$ getfacl --omit-header --no-effective d e f g
++	> user::rwx
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	> default:user::rwx
++	> default:user:bin:rwx
++	> default:group::r-x
++	> default:mask::rwx
++	> default:other::r-x
++	>
++	> user::rwx
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	> default:user::rwx
++	> default:user:bin:rwx
++	> default:group::r-x
++	> default:mask::rwx
++	> default:other::r-x
++	>
++	> user::rw-
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rw-
++	> other::r--
++	>
++	> user::rw-
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rw-
++	> other::r--
++	>
++
++	$ rm f g
++	$ rmdir d e
++	$ touch f g
++	$ mkdir d e
++	$ setfacl -n -m u:root:rwX f d g e
++	$ getfacl --omit-header --no-effective d e f g
++	> user::rwx
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	> default:user::rwx
++	> default:user:bin:rwx
++	> default:group::r-x
++	> default:mask::rwx
++	> default:other::r-x
++	>
++	> user::rwx
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rwx
++	> other::r-x
++	> default:user::rwx
++	> default:user:bin:rwx
++	> default:group::r-x
++	> default:mask::rwx
++	> default:other::r-x
++	>
++	> user::rw-
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rw-
++	> other::r--
++	>
++	> user::rw-
++	> user:root:rwx
++	> user:bin:rwx
++	> group::r-x
++	> mask::rw-
++	> other::r--
++	>
++
++	$ rm f g
++	$ rmdir d e
++	$ cd ..
++	$ rm -rf d
+Index: acl/test/setfacl-X.test
+===================================================================
+--- acl.orig/test/setfacl-X.test
++++ /dev/null
+@@ -1,119 +0,0 @@
+-	$ umask 022
+-	$ mkdir d
+-	$ cd d
+-
+-	$ setfacl -dm u:bin:rwx .
+-
+-	$ touch f g
+-	$ chmod ugo+x f
+-	$ setfacl -m u:bin:rw,g::r g
+-	$ setfacl -m u:root:rwX f g
+-	$ getfacl --omit-header --no-effective f g
+-	> user::rwx
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	>
+-	> user::rw-
+-	> user:root:rw-
+-	> user:bin:rw-
+-	> group::r--
+-	> mask::rw-
+-	> other::r--
+-	>
+-
+-	$ rm f g
+-	$ touch f g
+-	$ mkdir d e
+-	$ setfacl -n -m u:root:rwX d f e g
+-	$ getfacl --omit-header --no-effective d e f g
+-	> user::rwx
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	> default:user::rwx
+-	> default:user:bin:rwx
+-	> default:group::r-x
+-	> default:mask::rwx
+-	> default:other::r-x
+-	>
+-	> user::rwx
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	> default:user::rwx
+-	> default:user:bin:rwx
+-	> default:group::r-x
+-	> default:mask::rwx
+-	> default:other::r-x
+-	>
+-	> user::rw-
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rw-
+-	> other::r--
+-	>
+-	> user::rw-
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rw-
+-	> other::r--
+-	>
+-
+-	$ rm f g
+-	$ rmdir d e
+-	$ touch f g
+-	$ mkdir d e
+-	$ setfacl -n -m u:root:rwX f d g e
+-	$ getfacl --omit-header --no-effective d e f g
+-	> user::rwx
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	> default:user::rwx
+-	> default:user:bin:rwx
+-	> default:group::r-x
+-	> default:mask::rwx
+-	> default:other::r-x
+-	>
+-	> user::rwx
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rwx
+-	> other::r-x
+-	> default:user::rwx
+-	> default:user:bin:rwx
+-	> default:group::r-x
+-	> default:mask::rwx
+-	> default:other::r-x
+-	>
+-	> user::rw-
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rw-
+-	> other::r--
+-	>
+-	> user::rw-
+-	> user:root:rwx
+-	> user:bin:rwx
+-	> group::r-x
+-	> mask::rw-
+-	> other::r--
+-	>
+-
+-	$ rm f g
+-	$ rmdir d e
+-	$ cd ..
+-	$ rm -rf d
+Index: acl/test/utf8-filenames.run
+===================================================================
+--- /dev/null
++++ acl/test/utf8-filenames.run
+@@ -0,0 +1,14 @@
+++Test the setfacl --restore with utf8 paths.
+++Regression test: https://bugzilla.redhat.com/show_bug.cgi?id=183181
++
++The utf string UPATH is 250 bytes long and is repeated 4 times to create the
++path that setfacl will use. This size should work on systems with a small 255
++NAME_MAX.
++
++       $ export UPATH="官官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話話官話官話官話>官話官話話官話官"
++       $ mkdir -p $UPATH/$UPATH/$UPATH
++       $ touch $UPATH/$UPATH/$UPATH/$UPATH
++       $ getfacl $UPATH/$UPATH/$UPATH/$UPATH > utf8-filenames.acl
++       $ setfacl  --restore=utf8-filenames.acl
++       $ rm -R $UPATH
++       $ rm utf8-filenames.acl
+Index: acl/test/utf8-filenames.test
+===================================================================
+--- acl.orig/test/utf8-filenames.test
++++ /dev/null
+@@ -1,14 +0,0 @@
+-+Test the setfacl --restore with utf8 paths.
+-+Regression test: https://bugzilla.redhat.com/show_bug.cgi?id=183181
+-
+-The utf string UPATH is 250 bytes long and is repeated 4 times to create the
+-path that setfacl will use. This size should work on systems with a small 255
+-NAME_MAX.
+-
+-       $ export UPATH="官官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話官話話官話官話官話>官話官話話官話官"
+-       $ mkdir -p $UPATH/$UPATH/$UPATH
+-       $ touch $UPATH/$UPATH/$UPATH/$UPATH
+-       $ getfacl $UPATH/$UPATH/$UPATH/$UPATH > utf8-filenames.acl
+-       $ setfacl  --restore=utf8-filenames.acl
+-       $ rm -R $UPATH
+-       $ rm utf8-filenames.acl

--- a/debian/patches/backport-0006-CVE-2026-54369.patch
+++ b/debian/patches/backport-0006-CVE-2026-54369.patch
@@ -1,0 +1,703 @@
+From 5906d2868ec8d3b08be556153696e6b1122eeeda Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Wed, 3 Jun 2026 00:53:04 +0200
+Subject: [PATCH] Add libacl _at function variants
+
+Add new libacl functions acl_get_file_at(), acl_set_file_at(),
+acl_delete_def_file_at(), and acl_extended_file_at() that take a directory file
+descriptor and an AT_* flags argument, similar to fstatat(2).
+
+The AT_* flags argument supports the AT_SYMLINK_NOFOLLOW and AT_EMPTY_PATH flags.
+
+Bump LT_CURRENT and LT_AGE to indicate a backwards-compatible change.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ exports                                       |   9 ++
+ include/acl.h                                 |   4 +
+ include/libacl.h                              |   1 +
+ libacl/Makemodule.am                          |  14 ++-
+ libacl/__acl_extended_file.h                  |   3 -
+ libacl/acl_delete_def_file_at.c               |  45 ++++++++
+ libacl/acl_extended_file.c                    |   7 +-
+ ...extended_file.c => acl_extended_file_at.c} |  20 ++--
+ libacl/acl_extended_file_nofollow.c           |   7 +-
+ libacl/acl_get_file.c                         |  71 +-----------
+ libacl/acl_get_file_at.c                      | 107 ++++++++++++++++++
+ libacl/acl_set_file.c                         |  38 +------
+ libacl/acl_set_file_at.c                      |  71 ++++++++++++
+ 13 files changed, 268 insertions(+), 129 deletions(-)
+ delete mode 100644 libacl/__acl_extended_file.h
+ create mode 100644 libacl/acl_delete_def_file_at.c
+ rename libacl/{__acl_extended_file.c => acl_extended_file_at.c} (71%)
+ create mode 100644 libacl/acl_get_file_at.c
+ create mode 100644 libacl/acl_set_file_at.c
+
+Index: acl/exports
+===================================================================
+--- acl.orig/exports
++++ acl/exports
+@@ -75,3 +75,12 @@ ACL_1.2 {
+ 	# Linux specific extensions
+ 	acl_extended_file_nofollow;
+ } ACL_1.1;
++
++ACL_1.3 {
++    global:
++	# Linux specific extensions
++	acl_delete_def_file_at;
++	acl_extended_file_at;
++	acl_get_file_at;
++	acl_set_file_at;
++} ACL_1.2;
+Index: acl/include/acl.h
+===================================================================
+--- acl.orig/include/acl.h
++++ acl/include/acl.h
+@@ -114,10 +114,14 @@ EXPORT char *acl_to_text(acl_t acl, ssiz
+ /*=== Object manipulation ===*/
+ 
+ EXPORT int acl_delete_def_file(const char *path_p);
++EXPORT int acl_delete_def_file_at(int dirfd, const char *path_p, int at_flags);
+ EXPORT acl_t acl_get_fd(int fd);
+ EXPORT acl_t acl_get_file(const char *path_p, acl_type_t type);
++EXPORT acl_t acl_get_file_at(int dirfd, const char *path_p, int at_flags, acl_type_t type);
+ EXPORT int acl_set_fd(int fd, acl_t acl);
+ EXPORT int acl_set_file(const char *path_p, acl_type_t type, acl_t acl);
++EXPORT int acl_set_file_at(int dirfd, const char *path_p, int at_flags, acl_type_t type,
++			   acl_t acl);
+ 
+ #ifdef __cplusplus
+ }
+Index: acl/include/libacl.h
+===================================================================
+--- acl.orig/include/libacl.h
++++ acl/include/libacl.h
+@@ -60,6 +60,7 @@ EXPORT acl_t acl_from_mode(mode_t mode);
+ EXPORT int acl_equiv_mode(acl_t acl, mode_t *mode_p);
+ EXPORT int acl_extended_file(const char *path_p);
+ EXPORT int acl_extended_file_nofollow(const char *path_p);
++EXPORT int acl_extended_file_at(int dirfd, const char *path_p, int at_flags);
+ EXPORT int acl_extended_fd(int fd);
+ EXPORT int acl_entries(acl_t acl);
+ EXPORT const char *acl_error(int code);
+Index: acl/libacl/Makemodule.am
+===================================================================
+--- acl.orig/libacl/Makemodule.am
++++ acl/libacl/Makemodule.am
+@@ -2,10 +2,10 @@ lib_LTLIBRARIES += libacl.la
+ 
+ # No other library exports version info, otherwise we'd have to add
+ # "libacl_" prefix to all these variables.
+-LT_CURRENT = 2
++LT_CURRENT = 3
+ # The configure script will set this for us automatically.
+ #LT_REVISION =
+-LT_AGE = 1
++LT_AGE = 2
+ LTVERSION = $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
+ 
+ CFILES = $(POSIX_CFILES) $(LIBACL_CFILES) $(INTERNAL_CFILES) \
+@@ -17,8 +17,7 @@ HFILES = \
+ 	libacl/byteorder.h \
+ 	libacl/__acl_from_xattr.h \
+ 	libacl/__acl_to_xattr.h \
+-	libacl/perm_copy.h \
+-	libacl/__acl_extended_file.h
++	libacl/perm_copy.h
+ 
+ POSIX_CFILES = \
+ 	libacl/acl_add_perm.c \
+@@ -29,6 +28,7 @@ POSIX_CFILES = \
+ 	libacl/acl_copy_int.c \
+ 	libacl/acl_create_entry.c \
+ 	libacl/acl_delete_def_file.c \
++	libacl/acl_delete_def_file_at.c \
+ 	libacl/acl_delete_entry.c \
+ 	libacl/acl_delete_perm.c \
+ 	libacl/acl_dup.c \
+@@ -37,6 +37,7 @@ POSIX_CFILES = \
+ 	libacl/acl_get_entry.c \
+ 	libacl/acl_get_fd.c \
+ 	libacl/acl_get_file.c \
++	libacl/acl_get_file_at.c \
+ 	libacl/acl_get_perm.c \
+ 	libacl/acl_get_permset.c \
+ 	libacl/acl_get_qualifier.c \
+@@ -44,6 +45,7 @@ POSIX_CFILES = \
+ 	libacl/acl_init.c \
+ 	libacl/acl_set_fd.c \
+ 	libacl/acl_set_file.c \
++	libacl/acl_set_file_at.c \
+ 	libacl/acl_set_permset.c \
+ 	libacl/acl_set_qualifier.c \
+ 	libacl/acl_set_tag_type.c \
+@@ -59,10 +61,10 @@ LIBACL_CFILES = \
+ 	libacl/acl_error.c \
+ 	libacl/acl_extended_fd.c \
+ 	libacl/acl_extended_file.c \
++	libacl/acl_extended_file_at.c \
+ 	libacl/acl_extended_file_nofollow.c \
+ 	libacl/acl_from_mode.c \
+-	libacl/acl_to_any_text.c \
+-	libacl/__acl_extended_file.c
++	libacl/acl_to_any_text.c
+ 
+ INTERNAL_CFILES = \
+ 	libacl/__acl_from_xattr.c \
+Index: acl/libacl/__acl_extended_file.h
+===================================================================
+--- acl.orig/libacl/__acl_extended_file.h
++++ /dev/null
+@@ -1,3 +0,0 @@
+-int __acl_extended_file(const char *path_p,
+-			ssize_t (*)(const char *, const char *,
+-				    void *, size_t));
+Index: acl/libacl/acl_delete_def_file_at.c
+===================================================================
+--- /dev/null
++++ acl/libacl/acl_delete_def_file_at.c
+@@ -0,0 +1,45 @@
++/*
++  File: acl_delete_def_file_at.c
++
++  Copyright (C) 1999, 2000
++  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/types.h>
++#include <sys/xattr.h>
++#include <fcntl.h>
++#include "acl_ea.h"
++#include "xattrat_compat.h"
++#include "libacl.h"
++
++int
++acl_delete_def_file_at(int dirfd, const char *path_p, int at_flags)
++{
++	int error;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++
++	error = removexattrat(dirfd, path_p, at_flags, ACL_EA_DEFAULT);
++	if (error < 0 && errno != ENOATTR && errno != ENODATA)
++		return -1;
++	return 0;
++}
++
+Index: acl/libacl/acl_extended_file.c
+===================================================================
+--- acl.orig/libacl/acl_extended_file.c
++++ acl/libacl/acl_extended_file.c
+@@ -19,16 +19,13 @@
+ */
+ 
+ #include "config.h"
+-#include <unistd.h>
+-#include <sys/xattr.h>
++#include <fcntl.h>
+ #include "libacl.h"
+ 
+-#include "__acl_extended_file.h"
+-
+ 
+ int
+ acl_extended_file(const char *path_p)
+ {
+-	return __acl_extended_file(path_p, getxattr);
++	return acl_extended_file_at(AT_FDCWD, path_p, 0);
+ }
+ 
+Index: acl/libacl/__acl_extended_file.c
+===================================================================
+--- acl.orig/libacl/__acl_extended_file.c
++++ /dev/null
+@@ -1,47 +0,0 @@
+-/*
+-  File: __acl_extended_file.c
+-
+-  Copyright (C) 2000, 2011
+-  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, see <https://www.gnu.org/licenses/>.
+-*/
+-
+-#include "config.h"
+-#include <unistd.h>
+-#include <sys/xattr.h>
+-#include "libacl.h"
+-#include "acl_ea.h"
+-#include "__acl_extended_file.h"
+-
+-int
+-__acl_extended_file(const char *path_p,
+-		    ssize_t (*fun)(const char *, const char *,
+-				   void *, size_t))
+-{
+-	int base_size = sizeof(acl_ea_header) + 3 * sizeof(acl_ea_entry);
+-	int retval;
+-
+-	retval = fun(path_p, ACL_EA_ACCESS, NULL, 0);
+-	if (retval < 0 && errno != ENOATTR && errno != ENODATA)
+-		return -1;
+-	if (retval > base_size)
+-		return 1;
+-	retval = fun(path_p, ACL_EA_DEFAULT, NULL, 0);
+-	if (retval < 0 && errno != ENOATTR && errno != ENODATA)
+-		return -1;
+-	if (retval >= base_size)
+-		return 1;
+-	return 0;
+-}
+Index: acl/libacl/acl_extended_file_at.c
+===================================================================
+--- /dev/null
++++ acl/libacl/acl_extended_file_at.c
+@@ -0,0 +1,53 @@
++/*
++  File: acl_extended_file_at.c
++
++  Copyright (C) 2000, 2011
++  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <unistd.h>
++#include <sys/xattr.h>
++#include <fcntl.h>
++#include "libacl.h"
++#include "xattrat_compat.h"
++#include "acl_ea.h"
++
++
++int
++acl_extended_file_at(int dirfd, const char *path_p, int at_flags)
++{
++	int base_size = sizeof(acl_ea_header) + 3 * sizeof(acl_ea_entry);
++	int retval;
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++
++	retval = getxattrat(dirfd, path_p, at_flags, ACL_EA_ACCESS, NULL, 0);
++	if (retval < 0 && errno != ENOATTR && errno != ENODATA)
++		return -1;
++	if (retval > base_size)
++		return 1;
++	retval = getxattrat(dirfd, path_p, at_flags, ACL_EA_DEFAULT, NULL, 0);
++	if (retval < 0 && errno != ENOATTR && errno != ENODATA)
++		return -1;
++	if (retval >= base_size)
++		return 1;
++	return 0;
++}
+Index: acl/libacl/acl_extended_file_nofollow.c
+===================================================================
+--- acl.orig/libacl/acl_extended_file_nofollow.c
++++ acl/libacl/acl_extended_file_nofollow.c
+@@ -19,15 +19,12 @@
+ */
+ 
+ #include "config.h"
+-#include <unistd.h>
+-#include <sys/xattr.h>
++#include <fcntl.h>
+ #include "libacl.h"
+ 
+-#include "__acl_extended_file.h"
+-
+ 
+ int
+ acl_extended_file_nofollow(const char *path_p)
+ {
+-	return __acl_extended_file(path_p, lgetxattr);
++	return acl_extended_file_at(AT_FDCWD, path_p, AT_SYMLINK_NOFOLLOW);
+ }
+Index: acl/libacl/acl_get_file.c
+===================================================================
+--- acl.orig/libacl/acl_get_file.c
++++ acl/libacl/acl_get_file.c
+@@ -1,8 +1,7 @@
+ /*
+   File: acl_get_file.c
+ 
+-  Copyright (C) 1999, 2000
+-  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ 
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+@@ -19,77 +18,13 @@
+ */
+ 
+ #include "config.h"
+-#include <sys/types.h>
+-#include <sys/stat.h>
+-#include <unistd.h>
+-#include <stdio.h>
+-#include <sys/xattr.h>
++#include <fcntl.h>
+ #include "libacl.h"
+-#include "__acl_from_xattr.h"
+-#include "acl_ea.h"
+ 
+ /* 23.4.16 */
+ acl_t
+ acl_get_file(const char *path_p, acl_type_t type)
+ {
+-	size_t size_guess = acl_ea_size(16);
+-	char *onstack_buffer = alloca(size_guess);
+-	char *ext_acl_p = onstack_buffer;
+-	const char *name;
+-	acl_t acl = NULL;
+-	int retries = 0;
+-	int retval;
+-
+-	switch(type) {
+-		case ACL_TYPE_ACCESS:
+-			name = ACL_EA_ACCESS;
+-			break;
+-		case ACL_TYPE_DEFAULT:
+-			name = ACL_EA_DEFAULT;
+-			break;
+-		default:
+-			errno = EINVAL;
+-			goto out;
+-	}
+-
+-	for (;;) {
+-		retval = getxattr(path_p, name, ext_acl_p, size_guess);
+-		if (retval != -1 || errno != ERANGE)
+-			break;
+-		if (++retries >= 8)
+-			break;
+-
+-		retval = getxattr(path_p, name, NULL, 0);
+-		if (retval <= 0)
+-			break;
+-		size_guess = retval;
+-
+-		if (ext_acl_p != onstack_buffer)
+-			free(ext_acl_p);
+-		ext_acl_p = malloc(size_guess);
+-		if (!ext_acl_p)
+-			goto out;
+-	}
+-	if (retval > 0) {
+-		acl = __acl_from_xattr(ext_acl_p, retval);
+-	} else if (retval == 0 || errno == ENOATTR || errno == ENODATA) {
+-		struct stat st;
+-
+-		if (stat(path_p, &st) != 0)
+-			goto out;
+-
+-		if (type == ACL_TYPE_DEFAULT) {
+-			if (S_ISDIR(st.st_mode))
+-				acl = acl_init(0);
+-			else
+-				errno = EACCES;
+-		} else
+-			acl = acl_from_mode(st.st_mode);
+-	}
+-
+-out:
+-	if (ext_acl_p != onstack_buffer)
+-		free(ext_acl_p);
+-	return acl;
++	return acl_get_file_at(AT_FDCWD, path_p, 0, type);
+ }
+ 
+Index: acl/libacl/acl_get_file_at.c
+===================================================================
+--- /dev/null
++++ acl/libacl/acl_get_file_at.c
+@@ -0,0 +1,107 @@
++/*
++  File: acl_get_file_at.c
++
++  Copyright (C) 1999, 2000
++  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <stdio.h>
++#include <sys/xattr.h>
++#include <fcntl.h>
++#include "libacl.h"
++#include "xattrat_compat.h"
++#include "__acl_from_xattr.h"
++#include "acl_ea.h"
++
++acl_t
++acl_get_file_at(int dirfd, const char *path_p, int at_flags, acl_type_t type)
++{
++	size_t size_guess = acl_ea_size(16);
++	char *onstack_buffer = alloca(size_guess);
++	char *ext_acl_p = onstack_buffer;
++	const char *name;
++	acl_t acl = NULL;
++	int retries = 0;
++	int retval;
++
++	switch(type) {
++		case ACL_TYPE_ACCESS:
++			name = ACL_EA_ACCESS;
++			break;
++		case ACL_TYPE_DEFAULT:
++			name = ACL_EA_DEFAULT;
++			break;
++		default:
++			errno = EINVAL;
++			goto out;
++	}
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		goto out;
++	}
++
++	for (;;) {
++		retval = getxattrat(dirfd, path_p, at_flags, name, ext_acl_p,
++				    size_guess);
++		if (retval != -1 || errno != ERANGE)
++			break;
++		if (++retries >= 8)
++			break;
++
++		retval = getxattrat(dirfd, path_p, at_flags, name, NULL, 0);
++		if (retval <= 0)
++			break;
++		size_guess = retval;
++
++		if (ext_acl_p != onstack_buffer)
++			free(ext_acl_p);
++		ext_acl_p = malloc(size_guess);
++		if (!ext_acl_p)
++                       goto out;
++	}
++	if (retval > 0) {
++		acl = __acl_from_xattr(ext_acl_p, retval);
++	} else if (retval == 0 || errno == ENOATTR || errno == ENODATA) {
++		struct stat st;
++
++		if (fstatat(dirfd, path_p, &st, at_flags) != 0)
++			goto out;
++
++		if (S_ISLNK(st.st_mode)) {
++			errno = ENOTSUP;
++			goto out;
++		}
++		if (type == ACL_TYPE_DEFAULT) {
++			if (S_ISDIR(st.st_mode))
++				acl = acl_init(0);
++			else
++				errno = EACCES;
++		} else
++			acl = acl_from_mode(st.st_mode);
++	}
++
++out:
++	if (ext_acl_p != onstack_buffer)
++		free(ext_acl_p);
++	return acl;
++}
++
+Index: acl/libacl/acl_set_file.c
+===================================================================
+--- acl.orig/libacl/acl_set_file.c
++++ acl/libacl/acl_set_file.c
+@@ -1,8 +1,7 @@
+ /*
+   File: acl_set_file.c
+ 
+-  Copyright (C) 1999, 2000
+-  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ 
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+@@ -19,44 +18,13 @@
+ */
+ 
+ #include "config.h"
+-#include <sys/types.h>
+-#include <sys/stat.h>
+-#include <unistd.h>
+-#include <sys/xattr.h>
++#include <fcntl.h>
+ #include "libacl.h"
+-#include "__acl_to_xattr.h"
+-#include "acl_ea.h"
+-
+ 
+ /* 23.4.22 */
+ int
+ acl_set_file(const char *path_p, acl_type_t type, acl_t acl)
+ {
+-	acl_obj *acl_obj_p = ext2int(acl, acl);
+-	char *ext_acl_p;
+-	const char *name;
+-	size_t size;
+-	int error;
+-
+-	if (!acl_obj_p)
+-		return -1;
+-	switch (type) {
+-		case ACL_TYPE_ACCESS:
+-			name = ACL_EA_ACCESS;
+-			break;
+-		case ACL_TYPE_DEFAULT:
+-			name = ACL_EA_DEFAULT;
+-			break;
+-		default:
+-			errno = EINVAL;
+-			return -1;
+-	}
+-
+-	ext_acl_p = __acl_to_xattr(acl_obj_p, &size);
+-	if (!ext_acl_p)
+-		return -1;
+-	error = setxattr(path_p, name, (char *)ext_acl_p, size, 0);
+-	free(ext_acl_p);
+-	return error;
++	return acl_set_file_at(AT_FDCWD, path_p, 0, type, acl);
+ }
+ 
+Index: acl/libacl/acl_set_file_at.c
+===================================================================
+--- /dev/null
++++ acl/libacl/acl_set_file_at.c
+@@ -0,0 +1,71 @@
++/*
++  File: acl_set_file_at.c
++
++  Copyright (C) 1999, 2000
++  Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright (C) 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <sys/xattr.h>
++#include <fcntl.h>
++#include "libacl.h"
++#include "xattrat_compat.h"
++#include "__acl_to_xattr.h"
++#include "acl_ea.h"
++
++
++int
++acl_set_file_at(int dirfd, const char *path_p, int at_flags, acl_type_t type,
++		acl_t acl)
++{
++	acl_obj *acl_obj_p = ext2int(acl, acl);
++	char *ext_acl_p;
++	const char *name;
++	size_t size;
++	int error;
++
++	if (!acl_obj_p)
++		return -1;
++	switch (type) {
++		case ACL_TYPE_ACCESS:
++			name = ACL_EA_ACCESS;
++			break;
++		case ACL_TYPE_DEFAULT:
++			name = ACL_EA_DEFAULT;
++			break;
++		default:
++			errno = EINVAL;
++			return -1;
++	}
++
++	if (at_flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)) {
++		errno = EINVAL;
++		return -1;
++	}
++
++	ext_acl_p = __acl_to_xattr(acl_obj_p, &size);
++	if (!ext_acl_p)
++		return -1;
++	error = setxattrat(dirfd, path_p, at_flags, name, (char *)ext_acl_p,
++			   size, 0);
++	free(ext_acl_p);
++	return error;
++}
++

--- a/debian/patches/backport-0006-CVE-2026-54370.patch
+++ b/debian/patches/backport-0006-CVE-2026-54370.patch
@@ -1,0 +1,726 @@
+From f7210d140298ccc73b2b1713635e7c39d58a8eeb Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Tue, 9 Jun 2026 08:15:30 +0200
+Subject: [PATCH] Rename walk_tree to old_walk_tree
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ include/Makemodule.am                    | 2 +-
+ include/{walk_tree.h => old_walk_tree.h} | 4 ++--
+ libmisc/Makemodule.am                    | 4 ++--
+ libmisc/{walk_tree.c => old_walk_tree.c} | 6 +++---
+ tools/do_set.c                           | 2 +-
+ tools/getfacl.c                          | 6 +++---
+ tools/setfacl.c                          | 6 +++---
+ 7 files changed, 15 insertions(+), 15 deletions(-)
+ rename include/{walk_tree.h => old_walk_tree.h} (92%)
+ rename libmisc/{walk_tree.c => old_walk_tree.c} (98%)
+
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -4,8 +4,8 @@ noinst_HEADERS += \
+ 	include/acl_ea.h \
+ 	include/fchmodat_compat.h \
+ 	include/misc.h \
++	include/old_walk_tree.h \
+ 	include/visibility-hidden.h \
+-	include/walk_tree.h \
+ 	include/xattrat.h \
+ 	include/xattrat_compat.h
+ 
+Index: acl/include/walk_tree.h
+===================================================================
+--- acl.orig/include/walk_tree.h
++++ acl/include/walk_tree.h
+@@ -1,42 +0,0 @@
+-/*
+-  File: walk_tree.h
+-
+-  Copyright (C) 2007 Andreas Gruenbacher <a.gruenbacher@computer.org>
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, see <https://www.gnu.org/licenses/>.
+-*/
+-
+-#ifndef __WALK_TREE_H
+-#define __WALK_TREE_H
+-
+-#define WALK_TREE_RECURSIVE		0x01
+-#define WALK_TREE_PHYSICAL		0x02
+-#define WALK_TREE_LOGICAL		0x04
+-#define WALK_TREE_DEREFERENCE		0x08
+-#define WALK_TREE_DEREFERENCE_TOPLEVEL	0x10
+-#define WALK_TREE_ONE_FILESYSTEM	0x20
+-
+-#define WALK_TREE_TOPLEVEL	0x100
+-#define WALK_TREE_SYMLINK	0x200
+-#define WALK_TREE_FAILED	0x400
+-
+-struct stat;
+-
+-#define walk_tree __acl_walk_tree
+-
+-extern int walk_tree(const char *path, int walk_flags, unsigned int num,
+-		     int (*func)(const char *, const struct stat *, int,
+-				 void *), void *arg);
+-
+-#endif
+Index: acl/include/old_walk_tree.h
+===================================================================
+--- /dev/null
++++ acl/include/old_walk_tree.h
+@@ -0,0 +1,42 @@
++/*
++  File: old_walk_tree.h
++
++  Copyright (C) 2007 Andreas Gruenbacher <a.gruenbacher@computer.org>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#ifndef __WALK_TREE_H
++#define __WALK_TREE_H
++
++#define WALK_TREE_RECURSIVE		0x01
++#define WALK_TREE_PHYSICAL		0x02
++#define WALK_TREE_LOGICAL		0x04
++#define WALK_TREE_DEREFERENCE		0x08
++#define WALK_TREE_DEREFERENCE_TOPLEVEL	0x10
++#define WALK_TREE_ONE_FILESYSTEM	0x20
++
++#define WALK_TREE_TOPLEVEL	0x100
++#define WALK_TREE_SYMLINK	0x200
++#define WALK_TREE_FAILED	0x400
++
++struct stat;
++
++#define walk_tree __acl_walk_tree
++
++extern int old_walk_tree(const char *path, int walk_flags, unsigned int num,
++		     int (*func)(const char *, const struct stat *, int,
++				 void *), void *arg);
++
++#endif
+Index: acl/libmisc/walk_tree.c
+===================================================================
+--- acl.orig/libmisc/walk_tree.c
++++ acl/libmisc/walk_tree.c
+@@ -1,258 +0,0 @@
+-/*
+-  File: walk_tree.c
+-
+-  Copyright (C) 2007 Andreas Gruenbacher <a.gruenbacher@computer.org>
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, see <https://www.gnu.org/licenses/>.
+-*/
+-
+-#include "config.h"
+-#include <sys/types.h>
+-#include <sys/stat.h>
+-#include <unistd.h>
+-#include <sys/time.h>
+-#include <sys/resource.h>
+-#include <dirent.h>
+-#include <stdio.h>
+-#include <string.h>
+-#include <errno.h>
+-
+-#include "walk_tree.h"
+-
+-struct entry_handle {
+-	struct entry_handle *prev, *next;
+-	dev_t dev;
+-	ino_t ino;
+-	DIR *stream;
+-	long pos;
+-};
+-
+-struct walk_tree_args {
+-	char path[FILENAME_MAX];
+-	int walk_flags;
+-	int (*func)(const char *, const struct stat *, int, void *);
+-	void *arg;
+-	int depth;
+-	struct entry_handle dirs;
+-	struct entry_handle *closed;
+-	unsigned int num_dir_handles;
+-	struct stat st;
+-	dev_t dev;
+-};
+-
+-static int walk_tree_visited(struct entry_handle *dirs, dev_t dev, ino_t ino)
+-{
+-	struct entry_handle *i;
+-
+-	for (i = dirs->next; i != dirs; i = i->next)
+-		if (i->dev == dev && i->ino == ino)
+-			return 1;
+-	return 0;
+-}
+-
+-static int walk_tree_rec(struct walk_tree_args *args)
+-{
+-	int follow_symlinks = (args->walk_flags & WALK_TREE_LOGICAL) ||
+-			      ((args->walk_flags & WALK_TREE_DEREFERENCE) &&
+-			       !(args->walk_flags & WALK_TREE_PHYSICAL) &&
+-			       args->depth == 0);
+-	int have_dir_stat = 0, flags = args->walk_flags, err;
+-	struct entry_handle dir;
+-
+-	/*
+-	 * If (walk_flags & WALK_TREE_PHYSICAL), do not traverse symlinks.
+-	 * If (walk_flags & WALK_TREE_LOGICAL), traverse all symlinks.
+-	 * Otherwise, traverse only top-level symlinks.
+-	 */
+-	if (args->depth == 0)
+-		flags |= WALK_TREE_TOPLEVEL;
+-
+-	if (lstat(args->path, &args->st) != 0)
+-		return args->func(args->path, NULL, flags | WALK_TREE_FAILED,
+-				  args->arg);
+-
+-	if (flags & WALK_TREE_ONE_FILESYSTEM) {
+-		if (args->dev == 0)
+-			args->dev = args->st.st_dev;
+-		else if (args->st.st_dev != args->dev)
+-			return 0;
+-	}
+-
+-	if (S_ISLNK(args->st.st_mode)) {
+-		flags |= WALK_TREE_SYMLINK;
+-		if ((flags & WALK_TREE_DEREFERENCE) ||
+-		    ((flags & WALK_TREE_TOPLEVEL) &&
+-		     (flags & WALK_TREE_DEREFERENCE_TOPLEVEL))) {
+-			if (stat(args->path, &args->st) != 0)
+-				return args->func(args->path, NULL,
+-						  flags | WALK_TREE_FAILED,
+-						  args->arg);
+-			dir.dev = args->st.st_dev;
+-			dir.ino = args->st.st_ino;
+-			have_dir_stat = 1;
+-		}
+-	} else if (S_ISDIR(args->st.st_mode)) {
+-		dir.dev = args->st.st_dev;
+-		dir.ino = args->st.st_ino;
+-		have_dir_stat = 1;
+-	}
+-	err = args->func(args->path, &args->st, flags, args->arg);
+-
+-	/*
+-	 * Recurse if WALK_TREE_RECURSIVE and the path is:
+-	 *      a dir not from a symlink
+-	 *      a link and follow_symlinks
+-	 */
+-        if ((flags & WALK_TREE_RECURSIVE) &&
+-	    ((!(flags & WALK_TREE_SYMLINK) && S_ISDIR(args->st.st_mode)) ||
+-	     ((flags & WALK_TREE_SYMLINK) && follow_symlinks))) {
+-		struct dirent *entry;
+-
+-		/*
+-		 * Check if we have already visited this directory to break
+-		 * endless loops.
+-		 *
+-		 * If we haven't stat()ed the file yet, do an opendir() for
+-		 * figuring out whether we have a directory, and check whether
+-		 * the directory has been visited afterwards. This saves a
+-		 * system call for each non-directory found.
+-		 */
+-		if (have_dir_stat && walk_tree_visited(&args->dirs, dir.dev, dir.ino))
+-			return err;
+-
+-		if (args->num_dir_handles == 0 && args->closed->prev != &args->dirs) {
+-close_another_dir:
+-			/* Close the topmost directory handle still open. */
+-			args->closed = args->closed->prev;
+-			args->closed->pos = telldir(args->closed->stream);
+-			closedir(args->closed->stream);
+-			args->closed->stream = NULL;
+-			args->num_dir_handles++;
+-		}
+-
+-		dir.stream = opendir(args->path);
+-		if (!dir.stream) {
+-			if (errno == ENFILE && args->closed->prev != &args->dirs) {
+-				/* Ran out of file descriptors. */
+-				args->num_dir_handles = 0;
+-				goto close_another_dir;
+-			}
+-
+-			/*
+-			 * PATH may be a symlink to a regular file, or a dead
+-			 * symlink which we didn't follow above.
+-			 */
+-			if (errno != ENOTDIR && errno != ENOENT)
+-				err += args->func(args->path, NULL, flags |
+-						 WALK_TREE_FAILED, args->arg);
+-			return err;
+-		}
+-
+-		/* See walk_tree_visited() comment above... */
+-		if (!have_dir_stat) {
+-			if (stat(args->path, &args->st) != 0)
+-				goto skip_dir;
+-			dir.dev = args->st.st_dev;
+-			dir.ino = args->st.st_ino;
+-			if (walk_tree_visited(&args->dirs, dir.dev, dir.ino))
+-				goto skip_dir;
+-		}
+-
+-		/* Insert into the list of handles. */
+-		dir.next = args->dirs.next;
+-		dir.prev = &args->dirs;
+-		dir.prev->next = &dir;
+-		dir.next->prev = &dir;
+-		args->num_dir_handles--;
+-
+-		while ((entry = readdir(dir.stream)) != NULL) {
+-			char *path_end;
+-
+-			if (!strcmp(entry->d_name, ".") ||
+-			    !strcmp(entry->d_name, ".."))
+-				continue;
+-			path_end = strchr(args->path, 0);
+-			if ((path_end - args->path) + strlen(entry->d_name) + 1 >=
+-			    FILENAME_MAX) {
+-				errno = ENAMETOOLONG;
+-				err += args->func(args->path, NULL,
+-						  flags | WALK_TREE_FAILED,
+-						  args->arg);
+-				continue;
+-			}
+-			*path_end++ = '/';
+-			strcpy(path_end, entry->d_name);
+-			args->depth++;
+-			err += walk_tree_rec(args);
+-			args->depth--;
+-			*--path_end = 0;
+-			if (!dir.stream) {
+-				/* Reopen the directory handle. */
+-				dir.stream = opendir(args->path);
+-				if (!dir.stream)
+-					return err + args->func(args->path,
+-								NULL,
+-								flags | WALK_TREE_FAILED,
+-								args->arg);
+-				seekdir(dir.stream, dir.pos);
+-
+-				args->closed = args->closed->next;
+-				args->num_dir_handles--;
+-			}
+-		}
+-
+-		/* Remove from the list of handles. */
+-		dir.prev->next = dir.next;
+-		dir.next->prev = dir.prev;
+-		args->num_dir_handles++;
+-
+-	skip_dir:
+-		if (closedir(dir.stream) != 0)
+-			err += args->func(args->path, NULL,
+-					 flags | WALK_TREE_FAILED, args->arg);
+-	}
+-	return err;
+-}
+-
+-int walk_tree(const char *path, int walk_flags, unsigned int num,
+-	      int (*func)(const char *, const struct stat *, int, void *),
+-	      void *arg)
+-{
+-	struct walk_tree_args args;
+-
+-	args.num_dir_handles = num;
+-	if (args.num_dir_handles < 1) {
+-		struct rlimit rlimit;
+-
+-		args.num_dir_handles = 1;
+-		if (getrlimit(RLIMIT_NOFILE, &rlimit) == 0 &&
+-		    rlimit.rlim_cur >= 2)
+-			args.num_dir_handles = rlimit.rlim_cur / 2;
+-	}
+-	args.dirs.next = &args.dirs;
+-	args.dirs.prev = &args.dirs;
+-	args.closed = &args.dirs;
+-	if (strlen(path) >= FILENAME_MAX) {
+-		errno = ENAMETOOLONG;
+-		return func(path, NULL, WALK_TREE_FAILED, arg);
+-	}
+-	strcpy(args.path, path);
+-	args.walk_flags = walk_flags;
+-	args.func = func;
+-	args.arg = arg;
+-	args.depth = 0;
+-	args.dev = 0;
+-
+-	return walk_tree_rec(&args);
+-}
+Index: acl/libmisc/old_walk_tree.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/old_walk_tree.c
+@@ -0,0 +1,258 @@
++/*
++  File: old_walk_tree.c
++
++  Copyright (C) 2007 Andreas Gruenbacher <a.gruenbacher@computer.org>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <sys/time.h>
++#include <sys/resource.h>
++#include <dirent.h>
++#include <stdio.h>
++#include <string.h>
++#include <errno.h>
++
++#include "old_walk_tree.h"
++
++struct entry_handle {
++	struct entry_handle *prev, *next;
++	dev_t dev;
++	ino_t ino;
++	DIR *stream;
++	long pos;
++};
++
++struct walk_tree_args {
++	char path[FILENAME_MAX];
++	int walk_flags;
++	int (*func)(const char *, const struct stat *, int, void *);
++	void *arg;
++	int depth;
++	struct entry_handle dirs;
++	struct entry_handle *closed;
++	unsigned int num_dir_handles;
++	struct stat st;
++	dev_t dev;
++};
++
++static int walk_tree_visited(struct entry_handle *dirs, dev_t dev, ino_t ino)
++{
++	struct entry_handle *i;
++
++	for (i = dirs->next; i != dirs; i = i->next)
++		if (i->dev == dev && i->ino == ino)
++			return 1;
++	return 0;
++}
++
++static int walk_tree_rec(struct walk_tree_args *args)
++{
++	int follow_symlinks = (args->walk_flags & WALK_TREE_LOGICAL) ||
++			      ((args->walk_flags & WALK_TREE_DEREFERENCE) &&
++			       !(args->walk_flags & WALK_TREE_PHYSICAL) &&
++			       args->depth == 0);
++	int have_dir_stat = 0, flags = args->walk_flags, err;
++	struct entry_handle dir;
++
++	/*
++	 * If (walk_flags & WALK_TREE_PHYSICAL), do not traverse symlinks.
++	 * If (walk_flags & WALK_TREE_LOGICAL), traverse all symlinks.
++	 * Otherwise, traverse only top-level symlinks.
++	 */
++	if (args->depth == 0)
++		flags |= WALK_TREE_TOPLEVEL;
++
++	if (lstat(args->path, &args->st) != 0)
++		return args->func(args->path, NULL, flags | WALK_TREE_FAILED,
++				  args->arg);
++
++	if (flags & WALK_TREE_ONE_FILESYSTEM) {
++		if (args->dev == 0)
++			args->dev = args->st.st_dev;
++		else if (args->st.st_dev != args->dev)
++			return 0;
++	}
++
++	if (S_ISLNK(args->st.st_mode)) {
++		flags |= WALK_TREE_SYMLINK;
++		if ((flags & WALK_TREE_DEREFERENCE) ||
++		    ((flags & WALK_TREE_TOPLEVEL) &&
++		     (flags & WALK_TREE_DEREFERENCE_TOPLEVEL))) {
++			if (stat(args->path, &args->st) != 0)
++				return args->func(args->path, NULL,
++						  flags | WALK_TREE_FAILED,
++						  args->arg);
++			dir.dev = args->st.st_dev;
++			dir.ino = args->st.st_ino;
++			have_dir_stat = 1;
++		}
++	} else if (S_ISDIR(args->st.st_mode)) {
++		dir.dev = args->st.st_dev;
++		dir.ino = args->st.st_ino;
++		have_dir_stat = 1;
++	}
++	err = args->func(args->path, &args->st, flags, args->arg);
++
++	/*
++	 * Recurse if WALK_TREE_RECURSIVE and the path is:
++	 *      a dir not from a symlink
++	 *      a link and follow_symlinks
++	 */
++        if ((flags & WALK_TREE_RECURSIVE) &&
++	    ((!(flags & WALK_TREE_SYMLINK) && S_ISDIR(args->st.st_mode)) ||
++	     ((flags & WALK_TREE_SYMLINK) && follow_symlinks))) {
++		struct dirent *entry;
++
++		/*
++		 * Check if we have already visited this directory to break
++		 * endless loops.
++		 *
++		 * If we haven't stat()ed the file yet, do an opendir() for
++		 * figuring out whether we have a directory, and check whether
++		 * the directory has been visited afterwards. This saves a
++		 * system call for each non-directory found.
++		 */
++		if (have_dir_stat && walk_tree_visited(&args->dirs, dir.dev, dir.ino))
++			return err;
++
++		if (args->num_dir_handles == 0 && args->closed->prev != &args->dirs) {
++close_another_dir:
++			/* Close the topmost directory handle still open. */
++			args->closed = args->closed->prev;
++			args->closed->pos = telldir(args->closed->stream);
++			closedir(args->closed->stream);
++			args->closed->stream = NULL;
++			args->num_dir_handles++;
++		}
++
++		dir.stream = opendir(args->path);
++		if (!dir.stream) {
++			if (errno == ENFILE && args->closed->prev != &args->dirs) {
++				/* Ran out of file descriptors. */
++				args->num_dir_handles = 0;
++				goto close_another_dir;
++			}
++
++			/*
++			 * PATH may be a symlink to a regular file, or a dead
++			 * symlink which we didn't follow above.
++			 */
++			if (errno != ENOTDIR && errno != ENOENT)
++				err += args->func(args->path, NULL, flags |
++						 WALK_TREE_FAILED, args->arg);
++			return err;
++		}
++
++		/* See walk_tree_visited() comment above... */
++		if (!have_dir_stat) {
++			if (stat(args->path, &args->st) != 0)
++				goto skip_dir;
++			dir.dev = args->st.st_dev;
++			dir.ino = args->st.st_ino;
++			if (walk_tree_visited(&args->dirs, dir.dev, dir.ino))
++				goto skip_dir;
++		}
++
++		/* Insert into the list of handles. */
++		dir.next = args->dirs.next;
++		dir.prev = &args->dirs;
++		dir.prev->next = &dir;
++		dir.next->prev = &dir;
++		args->num_dir_handles--;
++
++		while ((entry = readdir(dir.stream)) != NULL) {
++			char *path_end;
++
++			if (!strcmp(entry->d_name, ".") ||
++			    !strcmp(entry->d_name, ".."))
++				continue;
++			path_end = strchr(args->path, 0);
++			if ((path_end - args->path) + strlen(entry->d_name) + 1 >=
++			    FILENAME_MAX) {
++				errno = ENAMETOOLONG;
++				err += args->func(args->path, NULL,
++						  flags | WALK_TREE_FAILED,
++						  args->arg);
++				continue;
++			}
++			*path_end++ = '/';
++			strcpy(path_end, entry->d_name);
++			args->depth++;
++			err += walk_tree_rec(args);
++			args->depth--;
++			*--path_end = 0;
++			if (!dir.stream) {
++				/* Reopen the directory handle. */
++				dir.stream = opendir(args->path);
++				if (!dir.stream)
++					return err + args->func(args->path,
++								NULL,
++								flags | WALK_TREE_FAILED,
++								args->arg);
++				seekdir(dir.stream, dir.pos);
++
++				args->closed = args->closed->next;
++				args->num_dir_handles--;
++			}
++		}
++
++		/* Remove from the list of handles. */
++		dir.prev->next = dir.next;
++		dir.next->prev = dir.prev;
++		args->num_dir_handles++;
++
++	skip_dir:
++		if (closedir(dir.stream) != 0)
++			err += args->func(args->path, NULL,
++					 flags | WALK_TREE_FAILED, args->arg);
++	}
++	return err;
++}
++
++int old_walk_tree(const char *path, int walk_flags, unsigned int num,
++	      int (*func)(const char *, const struct stat *, int, void *),
++	      void *arg)
++{
++	struct walk_tree_args args;
++
++	args.num_dir_handles = num;
++	if (args.num_dir_handles < 1) {
++		struct rlimit rlimit;
++
++		args.num_dir_handles = 1;
++		if (getrlimit(RLIMIT_NOFILE, &rlimit) == 0 &&
++		    rlimit.rlim_cur >= 2)
++			args.num_dir_handles = rlimit.rlim_cur / 2;
++	}
++	args.dirs.next = &args.dirs;
++	args.dirs.prev = &args.dirs;
++	args.closed = &args.dirs;
++	if (strlen(path) >= FILENAME_MAX) {
++		errno = ENAMETOOLONG;
++		return func(path, NULL, WALK_TREE_FAILED, arg);
++	}
++	strcpy(args.path, path);
++	args.walk_flags = walk_flags;
++	args.func = func;
++	args.arg = arg;
++	args.depth = 0;
++	args.dev = 0;
++
++	return walk_tree_rec(&args);
++}
+Index: acl/tools/do_set.c
+===================================================================
+--- acl.orig/tools/do_set.c
++++ acl/tools/do_set.c
+@@ -37,7 +37,7 @@
+ #include "sequence.h"
+ #include "do_set.h"
+ #include "parse.h"
+-#include "walk_tree.h"
++#include "old_walk_tree.h"
+ 
+ 
+ static acl_entry_t
+Index: acl/tools/getfacl.c
+===================================================================
+--- acl.orig/tools/getfacl.c
++++ acl/tools/getfacl.c
+@@ -37,7 +37,7 @@
+ #include <getopt.h>
+ #include "misc.h"
+ #include "user_group.h"
+-#include "walk_tree.h"
++#include "old_walk_tree.h"
+ 
+ #define POSIXLY_CORRECT_STR "POSIXLY_CORRECT"
+ 
+@@ -738,7 +738,7 @@ int main(int argc, char *argv[])
+ 				if (*line == '\0')
+ 					continue;
+ 
+-				had_errors += walk_tree(line, walk_flags, 0,
++				had_errors += old_walk_tree(line, walk_flags, 0,
+ 							do_print, NULL);
+ 			}
+ 			if (!feof(stdin)) {
+@@ -747,7 +747,7 @@ int main(int argc, char *argv[])
+ 				had_errors++;
+ 			}
+ 		} else
+-			had_errors += walk_tree(argv[optind], walk_flags, 0,
++			had_errors += old_walk_tree(argv[optind], walk_flags, 0,
+ 						do_print, NULL);
+ 		optind++;
+ 	} while (optind < argc);
+Index: acl/tools/setfacl.c
+===================================================================
+--- acl.orig/tools/setfacl.c
++++ acl/tools/setfacl.c
+@@ -33,7 +33,7 @@
+ #include "sequence.h"
+ #include "parse.h"
+ #include "do_set.h"
+-#include "walk_tree.h"
++#include "old_walk_tree.h"
+ 
+ #define POSIXLY_CORRECT_STR "POSIXLY_CORRECT"
+ 
+@@ -310,14 +310,14 @@ static int next_file(const char *arg, se
+ 
+ 	if (strcmp(arg, "-") == 0) {
+ 		while ((line = __acl_next_line(stdin)))
+-			errors = walk_tree(line, walk_flags, 0, do_set, &args);
++			errors = old_walk_tree(line, walk_flags, 0, do_set, &args);
+ 		if (!feof(stdin)) {
+ 			fprintf(stderr, _("%s: Standard input: %s\n"),
+ 				progname, strerror(errno));
+ 			errors = 1;
+ 		}
+ 	} else {
+-		errors = walk_tree(arg, walk_flags, 0, do_set, &args);
++		errors = old_walk_tree(arg, walk_flags, 0, do_set, &args);
+ 	}
+ 	return errors ? 1 : 0;
+ }

--- a/debian/patches/backport-0007-CVE-2026-54369.patch
+++ b/debian/patches/backport-0007-CVE-2026-54369.patch
@@ -1,0 +1,945 @@
+From 0071c6d1fea0a8a6270333baa85fb609be325c26 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Fri, 5 Jun 2026 06:21:41 +0200
+Subject: [PATCH] Add libacl _at function documentation
+
+Add man page documentation for acl_delete_def_file_at(), and
+acl_extended_file_at(), acl_get_file_at(), and acl_set_file_at().
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ man/man3/Makemodule.am            |   4 +
+ man/man3/acl_delete_def_file.3    | 113 +++++++++++++++++++++--
+ man/man3/acl_delete_def_file_at.3 |   1 +
+ man/man3/acl_extended_file.3      | 132 +++++++++++++++++++++++----
+ man/man3/acl_extended_file_at.3   |   1 +
+ man/man3/acl_get_file.3           | 137 +++++++++++++++++++++++++---
+ man/man3/acl_get_file_at.3        |   1 +
+ man/man3/acl_set_file.3           | 147 +++++++++++++++++++++++++++---
+ man/man3/acl_set_file_at.3        |   1 +
+ man/man5/acl.5                    |   8 +-
+ 10 files changed, 493 insertions(+), 52 deletions(-)
+ create mode 100644 man/man3/acl_delete_def_file_at.3
+ create mode 100644 man/man3/acl_extended_file_at.3
+ create mode 100644 man/man3/acl_get_file_at.3
+ create mode 100644 man/man3/acl_set_file_at.3
+
+Index: acl/man/man3/Makemodule.am
+===================================================================
+--- acl.orig/man/man3/Makemodule.am
++++ acl/man/man3/Makemodule.am
+@@ -9,6 +9,7 @@ dist_man_MANS += \
+ 	man/man3/acl_copy_int.3 \
+ 	man/man3/acl_create_entry.3 \
+ 	man/man3/acl_delete_def_file.3 \
++	man/man3/acl_delete_def_file_at.3 \
+ 	man/man3/acl_delete_entry.3 \
+ 	man/man3/acl_delete_perm.3 \
+ 	man/man3/acl_dup.3 \
+@@ -17,6 +18,7 @@ dist_man_MANS += \
+ 	man/man3/acl_error.3 \
+ 	man/man3/acl_extended_fd.3 \
+ 	man/man3/acl_extended_file.3 \
++	man/man3/acl_extended_file_at.3 \
+ 	man/man3/acl_extended_file_nofollow.3 \
+ 	man/man3/acl_free.3 \
+ 	man/man3/acl_from_mode.3 \
+@@ -24,6 +26,7 @@ dist_man_MANS += \
+ 	man/man3/acl_get_entry.3 \
+ 	man/man3/acl_get_fd.3 \
+ 	man/man3/acl_get_file.3 \
++	man/man3/acl_get_file_at.3 \
+ 	man/man3/acl_get_perm.3 \
+ 	man/man3/acl_get_permset.3 \
+ 	man/man3/acl_get_qualifier.3 \
+@@ -31,6 +34,7 @@ dist_man_MANS += \
+ 	man/man3/acl_init.3 \
+ 	man/man3/acl_set_fd.3 \
+ 	man/man3/acl_set_file.3 \
++	man/man3/acl_set_file_at.3 \
+ 	man/man3/acl_set_permset.3 \
+ 	man/man3/acl_set_qualifier.3 \
+ 	man/man3/acl_set_tag_type.3 \
+Index: acl/man/man3/acl_delete_def_file.3
+===================================================================
+--- acl.orig/man/man3/acl_delete_def_file.3
++++ acl/man/man3/acl_delete_def_file.3
+@@ -1,6 +1,6 @@
+ .\" Access Control Lists manual pages
+ .\"
+-.\" (C) 2002 Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++.\" (C) 2002-2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ .\"
+ .\" This is free documentation; you can redistribute it and/or
+ .\" modify it under the terms of the GNU General Public License as
+@@ -21,11 +21,12 @@
+ .\" License along with this manual.  If not, see
+ .\" <http://www.gnu.org/licenses/>.
+ .\"
+-.Dd March 23, 2002
++.Dd June 5, 2026
+ .Dt ACL_DELETE_DEF_FILE 3
+ .Os "Linux ACL"
+ .Sh NAME
+-.Nm acl_delete_def_file
++.Nm acl_delete_def_file ,
++.Nm acl_delete_def_file_at
+ .Nd delete a default ACL by filename
+ .Sh LIBRARY
+ Linux Access Control Lists library (libacl, \-lacl).
+@@ -33,7 +34,15 @@ Linux Access Control Lists library (liba
+ .In sys/types.h
+ .In sys/acl.h
+ .Ft int
+-.Fn acl_delete_def_file "const char *path_p"
++.Fo acl_delete_def_file
++.Fa "const char *path_p"
++.Fc
++.Ft int
++.Fo acl_delete_def_file_at
++.Fa "int dirfd"
++.Fa "const char *path_p"
++.Fa "int at_flags"
++.Fc
+ .Sh DESCRIPTION
+ The
+ .Fn acl_delete_def_file
+@@ -49,22 +58,108 @@ If the argument
+ is not a directory, then the function fails. It is no error if the directory whose pathname is pointed to by the argument
+ .Va path_p
+ does not have a default ACL.
++.Ss Fn acl_delete_def_file_at
++The
++.Fn acl_delete_def_file_at
++function operates in exactly the same way as
++.Fn acl_delete_def_file ,
++except for the differences described here.
++.Pp
++If the pathname given in
++.Va path_p
++is relative, then it is interpreted relative to the directory referred to by the file descriptor
++.Va dirfd
++(rather than relative to the current working directory of the calling process, as is done by
++.Fn acl_delete_def_file ) .
++.Pp
++If
++.Va path_p
++is relative and
++.Va dirfd
++is the special value
++.Dv AT_FDCWD ,
++then
++.Va path_p
++is interpreted relative to the current working directory of the calling process (like
++.Fn acl_delete_def_file ) .
++.Pp
++If
++.Va path_p
++is absolute, then
++.Va dirfd
++is ignored.
++.Pp
++The
++.Va at_flags
++argument can either be 0, or include one or more of the following flags ORed:
++.Bl -tag
++.It Dv AT_EMPTY_PATH
++If
++.Va path_p
++is an empty string, operate on the file referred to by
++.Va dirfd
++(which may have been obtained using the
++.Xr open 2
++.Dv O_PATH
++flag). In this case,
++.Va dirfd
++can refer to any type of file, not just a directory.
++.It Dv AT_SYMLINK_NOFOLLOW
++If
++.Va path_p
++refers to a symbolic link, do not dereference it: instead, fail the operation
++and set the global variable
++.Va errno
++to
++.Er ENOTSUP .
++This indicates that the symbolic link cannot have ACLs.
++.El
+ .Sh RETURN VALUE
+-.Rv -std acl_delete_def_file
++.Rv -std acl_delete_def_file acl_delete_def_file_at
+ .Sh ERRORS
+ If any of the following conditions occur, the
+ .Fn acl_delete_def_file
+-function returns the value
++and
++.Fn acl_delete_def_file_at
++functions return the value
+ .Li -1
+-and and sets
++and set
+ .Va errno
+ to the corresponding value:
+ .Bl -tag -width Er
++.It Bq Er EBADF
++The argument
++.Va path_p
++is relative but the argument
++.Va dirfd
++is neither
++.Dv AT_FDCWD
++nor a valid file descriptor.
+ .It Bq Er EINVAL
+ The file referred to by
+ .Va path_p
+ is not a directory.
++.Pp
++An invalid flag was specified in the
++.Va at_flags
++argument.
++.It Bq Er ENOTDIR
++A component of the path prefix is not a directory.
++.Pp
++The argument
++.Va path_p
++is relative and the argument
++.Va dirfd
++is a file descriptor referring to a file other than a directory.
+ .It Bq Er ENOTSUP
++The argument
++.Va at_flags
++includes the flag
++.Dv AT_SYMLINK_NOFOLLOW
++and
++.Va path_p
++is a symbolic link.
++.Pp
+ The file system on which the file identified by
+ .Va path_p
+ is located does not support ACLs, or ACLs are disabled.
+@@ -75,6 +170,10 @@ This function requires modification of a
+ .El
+ .Sh STANDARDS
+ IEEE Std 1003.1e draft 17 (\(lqPOSIX.1e\(rq, abandoned)
++.Pp
++Function
++.Fn acl_delete_def_file_at
++is a Linux specific extension.
+ .Sh SEE ALSO
+ .Xr acl_get_file 3 ,
+ .Xr acl_set_file 3 ,
+Index: acl/man/man3/acl_delete_def_file_at.3
+===================================================================
+--- /dev/null
++++ acl/man/man3/acl_delete_def_file_at.3
+@@ -0,0 +1 @@
++.so man3/acl_delete_def_file.3
+Index: acl/man/man3/acl_extended_file.3
+===================================================================
+--- acl.orig/man/man3/acl_extended_file.3
++++ acl/man/man3/acl_extended_file.3
+@@ -1,6 +1,6 @@
+ .\" Access Control Lists manual pages
+ .\"
+-.\" (C) 2002 Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++.\" (C) 2002-2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ .\"
+ .\" This is free documentation; you can redistribute it and/or
+ .\" modify it under the terms of the GNU General Public License as
+@@ -21,11 +21,13 @@
+ .\" License along with this manual.  If not, see
+ .\" <http://www.gnu.org/licenses/>.
+ .\"
+-.Dd March 23, 2002
++.Dd June 5, 2026
+ .Dt ACL_EXTENDED_FILE 3
+ .Os "Linux ACL"
+ .Sh NAME
+-.Nm acl_extended_file, acl_extended_file_nofollow
++.Nm acl_extended_file ,
++.Nm acl_extended_file_at ,
++.Nm acl_extended_file_nofollow
+ .Nd test for information in ACLs by file name
+ .Sh LIBRARY
+ Linux Access Control Lists library (libacl, \-lacl).
+@@ -33,9 +35,19 @@ Linux Access Control Lists library (liba
+ .In sys/types.h
+ .In acl/libacl.h
+ .Ft int
+-.Fn acl_extended_file "const char *path_p"
++.Fo acl_extended_file
++.Fa "const char *path_p"
++.Fc
+ .Ft int
+-.Fn acl_extended_file_nofollow "const char *path_p"
++.Fo acl_extended_file_at
++.Fa "int dirfd"
++.Fa "const char *path_p"
++.Fa "int at_flags"
++.Fc
++.Ft int
++.Fo acl_extended_file_nofollow
++.Fa "const char *path_p"
++.Fc
+ .Sh DESCRIPTION
+ The
+ .Fn acl_extended_file
+@@ -63,17 +75,77 @@ mechanisms, such as Mandatory Access Con
+ .Xr access 2
+ system call can be used to check whether a given type of access to a file
+ object would be granted.
+-.Pp
+-.Fn acl_extended_file_nofollow
+-is identical to
++.Ss Fn acl_extended_file_at
++The
++.Fn acl_extended_file_at
++function operates in exactly the same way as
+ .Fn acl_extended_file ,
+-except in the case of a symbolic link, where the link itself is interrogated,
+-not the file that it refers to.  Since symbolic links have no ACL themselves,
+-the operation is supposed to fail on them.
+-.Sh RETURN VALUE
+-If successful, the
++except for the differences described here.
++.Pp
++If the pathname given in
++.Va path_p
++is relative, then it is interpreted relative to the directory referred to by the file descriptor
++.Va dirfd
++(rather than relative to the current working directory of the calling process, as is done by
++.Fn acl_extended_file ) .
++.Pp
++If
++.Va path_p
++is relative and
++.Va dirfd
++is the special value
++.Dv AT_FDCWD ,
++then
++.Va path_p
++is interpreted relative to the current working directory of the calling process (like
++.Fn acl_extended_file ) .
++.Pp
++If
++.Va path_p
++is absolute, then
++.Va dirfd
++is ignored.
++.Pp
++The
++.Va at_flags
++argument can either be 0, or include one or more of the following flags ORed:
++.Bl -tag
++.It Dv AT_EMPTY_PATH
++If
++.Va path_p
++is an empty string, operate on the file referred to by
++.Va dirfd
++(which may have been obtained using the
++.Xr open 2
++.Dv O_PATH
++flag). In this case,
++.Va dirfd
++can refer to any type of file, not just a directory.
++.It Dv AT_SYMLINK_NOFOLLOW
++If
++.Va path_p
++refers to a symbolic link, do not dereference it: instead, fail the operation
++and set the global variable
++.Va errno
++to
++.Er ENOTSUP .
++This indicates that the symbolic link cannot have ACLs.
++.El
++.Ss Fn acl_extended_nofollow
++The
++.Fn acl_extended_file_at
++function operates in exactly the same way as
+ .Fn acl_extended_file
+-function returns
++with a
++.Va dirfd
++value of
++.Dv AT_FDCWD
++and an
++.Va at_flags
++value of
++.Dv AT_SYMLINK_NOFOLLOW .
++.Sh RETURN VALUE
++If successful, these functions return
+ .Li 1
+ if the file object referred to by
+ .Va path_p
+@@ -87,16 +159,26 @@ is returned and the global variable
+ .Va errno
+ is set to indicate the error.
+ .Sh ERRORS
+-If any of the following conditions occur, the
+-.Fn acl_extended_file
+-function returns
++If any of the following conditions occur, these functions return
+ .Li -1
+-and sets
++and set
+ .Va errno
+ to the corresponding value:
+ .Bl -tag -width Er
+ .It Bq Er EACCES
+ Search permission is denied for a component of the path prefix.
++.It Bq Er EBADF
++The argument
++.Va path_p
++is relative but the argument
++.Va dirfd
++is neither
++.Dv AT_FDCWD
++nor a valid file descriptor.
++.It Bq Er EINVAL
++An invalid flag was specified in the
++.Va at_flags
++argument.
+ .It Bq Er ENAMETOOLONG
+ The length of the argument
+ .Va path_p
+@@ -107,7 +189,21 @@ The named object does not exist or the a
+ points to an empty string.
+ .It Bq Er ENOTDIR
+ A component of the path prefix is not a directory.
++.Pp
++The argument
++.Va path_p
++is relative and the argument
++.Va dirfd
++is a file descriptor referring to a file other than a directory.
+ .It Bq Er ENOTSUP
++The argument
++.Va at_flags
++includes the flag
++.Dv AT_SYMLINK_NOFOLLOW
++and
++.Va path_p
++is a symbolic link.
++.Pp
+ The file system on which the file identified by
+ .Va path_p
+ is located does not support ACLs, or ACLs are disabled.
+Index: acl/man/man3/acl_extended_file_at.3
+===================================================================
+--- /dev/null
++++ acl/man/man3/acl_extended_file_at.3
+@@ -0,0 +1 @@
++.so man3/acl_extended_file.3
+\ No newline at end of file
+Index: acl/man/man3/acl_get_file.3
+===================================================================
+--- acl.orig/man/man3/acl_get_file.3
++++ acl/man/man3/acl_get_file.3
+@@ -1,6 +1,6 @@
+ .\" Access Control Lists manual pages
+ .\"
+-.\" (C) 2002 Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++.\" (C) 2002-2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ .\"
+ .\" This is free documentation; you can redistribute it and/or
+ .\" modify it under the terms of the GNU General Public License as
+@@ -21,11 +21,12 @@
+ .\" License along with this manual.  If not, see
+ .\" <http://www.gnu.org/licenses/>.
+ .\"
+-.Dd March 23, 2002
++.Dd June 5, 2026
+ .Dt ACL_GET_FILE 3
+ .Os "Linux ACL"
+ .Sh NAME
+-.Nm acl_get_file
++.Nm acl_get_file ,
++.Nm acl_get_file_at
+ .Nd get an ACL by filename
+ .Sh LIBRARY
+ Linux Access Control Lists library (libacl, \-lacl).
+@@ -33,7 +34,17 @@ Linux Access Control Lists library (liba
+ .In sys/types.h
+ .In sys/acl.h
+ .Ft acl_t
+-.Fn acl_get_file "const char *path_p" "acl_type_t type"
++.Fo acl_get_file
++.Fa "const char *path_p"
++.Fa "acl_type_t type"
++.Fc
++.Ft acl_t
++.Fo acl_get_file_at
++.Fa "int dirfd"
++.Fa "const char *path_p"
++.Fa "int at_flags"
++.Fa "acl_type_t type"
++.Fc
+ .Sh DESCRIPTION
+ The
+ .Fn acl_get_file
+@@ -52,15 +63,21 @@ is used to indicate whether the access A
+ .Va path_p
+ is returned. If
+ .Va type
+-is ACL_TYPE_ACCESS, the access ACL of
++is
++.Dv ACL_TYPE_ACCESS ,
++the access ACL of
+ .Va path_p
+ is returned. If
+ .Va type
+-is ACL_TYPE_DEFAULT, the default ACL of
++is
++.Dv ACL_TYPE_DEFAULT ,
++the default ACL of
+ .Va path_p
+ is returned. If
+ .Va type
+-is ACL_TYPE_DEFAULT and no default ACL is associated with the directory
++is
++.Dv ACL_TYPE_DEFAULT
++and no default ACL is associated with the directory
+ .Va path_p ,
+ then an ACL containing zero ACL entries is returned. If
+ .Va type
+@@ -76,8 +93,71 @@ with the
+ returned by
+ .Fn acl_get_file
+ as an argument.
++.Ss Fn acl_get_file_at
++The
++.Fn acl_get_file_at
++function operates in exactly the same way as
++.Fn acl_get_file ,
++except for the differences described here.
++.Pp
++If the pathname given in
++.Va path_p
++is relative, then it is interpreted relative to the directory referred to by the file descriptor
++.Va dirfd
++(rather than relative to the current working directory of the calling process, as is done by
++.Fn acl_get_file ) .
++.Pp
++If
++.Va path_p
++is relative and
++.Va dirfd
++is the special value
++.Dv AT_FDCWD ,
++then
++.Va path_p
++is interpreted relative to the current working directory of the calling process (like
++.Fn acl_get_file ) .
++.Pp
++If
++.Va path_p
++is absolute, then
++.Va dirfd
++is ignored.
++.Pp
++The
++.Va at_flags
++argument can either be 0, or include one or more of the following flags ORed:
++.Bl -tag
++.It Dv AT_EMPTY_PATH
++If
++.Va path_p
++is an empty string, operate on the file referred to by
++.Va dirfd
++(which may have been obtained using the
++.Xr open 2
++.Dv O_PATH
++flag). In this case,
++.Va dirfd
++can refer to any type of file, not just a directory, and the behavior of
++.Fn acl_get_file_at
++is similar to that of
++.Fn acl_get_fd .
++.It Dv AT_SYMLINK_NOFOLLOW
++If
++.Va path_p
++refers to a symbolic link, do not dereference it: instead, fail the operation
++and set the global variable
++.Va errno
++to
++.Er ENOTSUP .
++This indicates that the symbolic link cannot have ACLs.
++.El
+ .Sh RETURN VALUE
+-On success, this function returns a pointer to the
++On success, the
++.Fn acl_get_file
++and
++.Fn acl_get_file_at
++functions return a pointer to the
+ working storage.  On error, a value of
+ .Li (acl_t)NULL
+ is returned, and
+@@ -86,9 +166,11 @@ is set appropriately.
+ .Sh ERRORS
+ If any of the following conditions occur, the
+ .Fn acl_get_file
+-function returns a value of
++and
++.Fn acl_get_file_at
++functions return a value of
+ .Li (acl_t)NULL
+-and sets
++and set
+ .Va errno
+ to the corresponding value:
+ .Bl -tag -width Er
+@@ -100,10 +182,25 @@ Argument
+ .Va type
+ specifies a type of ACL that cannot be associated with
+ .Va path_p .
++.It Bq Er EBADF
++The argument
++.Va path_p
++is relative but the argument
++.Va dirfd
++is neither
++.Dv AT_FDCWD
++nor a valid file descriptor.
+ .It Bq Er EINVAL
+ The argument
+ .Va type
+-is not ACL_TYPE_ACCESS or ACL_TYPE_DEFAULT.
++is not
++.Dv ACL_TYPE_ACCESS
++or
++.Dv ACL_TYPE_DEFAULT .
++.Pp
++An invalid flag was specified in the
++.Va at_flags
++argument.
+ .It Bq Er ENAMETOOLONG
+ The length of the argument
+ .Va path_p
+@@ -116,13 +213,31 @@ points to an empty string.
+ The ACL working storage requires more memory than is allowed by the hardware or system-imposed memory management constraints.
+ .It Bq Er ENOTDIR
+ A component of the path prefix is not a directory.
++.Pp
++The argument
++.Va path_p
++is relative and the argument
++.Va dirfd
++is a file descriptor referring to a file other than a directory.
+ .It Bq Er ENOTSUP
++The argument
++.Va at_flags
++includes the flag
++.Dv AT_SYMLINK_NOFOLLOW
++and
++.Va path_p
++is a symbolic link.
++.Pp
+ The file system on which the file identified by
+ .Va path_p
+ is located does not support ACLs, or ACLs are disabled.
+ .El
+ .Sh STANDARDS
+ IEEE Std 1003.1e draft 17 (\(lqPOSIX.1e\(rq, abandoned)
++.Pp
++Function
++.Fn acl_get_file_at
++is a Linux specific extension.
+ .Sh SEE ALSO
+ .Xr acl_free 3 ,
+ .Xr acl_get_entry 3 ,
+Index: acl/man/man3/acl_get_file_at.3
+===================================================================
+--- /dev/null
++++ acl/man/man3/acl_get_file_at.3
+@@ -0,0 +1 @@
++.so man3/acl_get_file.3
+Index: acl/man/man3/acl_set_file.3
+===================================================================
+--- acl.orig/man/man3/acl_set_file.3
++++ acl/man/man3/acl_set_file.3
+@@ -1,6 +1,6 @@
+ .\" Access Control Lists manual pages
+ .\"
+-.\" (C) 2002 Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++.\" (C) 2002-2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+ .\"
+ .\" This is free documentation; you can redistribute it and/or
+ .\" modify it under the terms of the GNU General Public License as
+@@ -21,11 +21,12 @@
+ .\" License along with this manual.  If not, see
+ .\" <http://www.gnu.org/licenses/>.
+ .\"
+-.Dd March 23, 2002
++.Dd June 5, 2026
+ .Dt ACL_SET_FILE 3
+ .Os "Linux ACL"
+ .Sh NAME
+-.Nm acl_set_file
++.Nm acl_set_file ,
++.Nm acl_set_file_at
+ .Nd set an ACL by filename
+ .Sh LIBRARY
+ Linux Access Control Lists library (libacl, \-lacl).
+@@ -33,7 +34,19 @@ Linux Access Control Lists library (liba
+ .In sys/types.h
+ .In sys/acl.h
+ .Ft int
+-.Fn acl_set_file "const char *path_p" "acl_type_t type" "acl_t acl"
++.Fo acl_set_file
++.Fa "const char *path_p"
++.Fa "acl_type_t type"
++.Fa "acl_t acl"
++.Fc
++.Ft int
++.Fo acl_set_file_at
++.Fa "int dirfd"
++.Fa "const char *path_p"
++.Fa "int at_flags"
++.Fa "acl_type_t type"
++.Fa "acl_t acl"
++.Fc
+ .Sh DESCRIPTION
+ The
+ .Fn acl_set_file
+@@ -53,11 +66,15 @@ with
+ .Va path_p
+ is being set. If the
+ .Va type
+-parameter is ACL_TYPE_ACCESS, the access ACL of
++parameter is
++.Dv ACL_TYPE_ACCESS ,
++the access ACL of
+ .Va path_p
+ shall be set. If the
+ .Va type
+-parameter is ACL_TYPE_DEFAULT, the default ACL of
++parameter is
++.Dv ACL_TYPE_DEFAULT ,
++the default ACL of
+ .Va path_p
+ shall be set. If the argument
+ .Va type
+@@ -71,9 +88,13 @@ parameter must reference a valid ACL acc
+ .Xr acl_valid 3
+ manual page if the
+ .Va type
+-parameter is ACL_TYPE_ACCESS, and must either reference a valid ACL or an ACL with zero ACL entries if the
++parameter is
++.Dv ACL_TYPE_ACCESS ,
++and must either reference a valid ACL or an ACL with zero ACL entries if the
+ .Va type
+-parameter is ACL_TYPE_DEFAULT. If the
++parameter is
++.Dv ACL_TYPE_DEFAULT .
++If the
+ .Va acl
+ parameter references an empty ACL, then the
+ .Fn acl_set_file
+@@ -81,14 +102,75 @@ function removes any default ACL associa
+ by the
+ .Va path_p
+ parameter.
++.Ss Fn acl_set_file_at
++The
++.Fn acl_set_file_at
++function operates in exactly the same way as
++.Fn acl_set_file ,
++except for the differences described here.
++.Pp
++If the pathname given in
++.Va path_p
++is relative, then it is interpreted relative to the directory referred to by the file descriptor
++.Va dirfd
++(rather than relative to the current working directory of the calling process, as is done by
++.Fn acl_set_file ) .
++.Pp
++If
++.Va path_p
++is relative and
++.Va dirfd
++is the special value
++.Dv AT_FDCWD ,
++then
++.Va path_p
++is interpreted relative to the current working directory of the calling process (like
++.Fn acl_set_file ) .
++.Pp
++If
++.Va path_p
++is absolute, then
++.Va dirfd
++is ignored.
++.Pp
++The
++.Va at_flags
++argument can either be 0, or include one or more of the following flags ORed:
++.Bl -tag
++.It Dv AT_EMPTY_PATH
++If
++.Va path_p
++is an empty string, operate on the file referred to by
++.Va dirfd
++(which may have been obtained using the
++.Xr open 2
++.Dv O_PATH
++flag). In this case,
++.Va dirfd
++can refer to any type of file, not just a directory, and the behavior of
++.Fn acl_set_file_at
++is similar to that of
++.Fn acl_set_fd .
++.It Dv AT_SYMLINK_NOFOLLOW
++If
++.Va path_p
++refers to a symbolic link, do not dereference it: instead, fail the operation
++and set the global variable
++.Va errno
++to
++.Er ENOTSUP .
++This indicates that the symbolic link cannot have ACLs.
++.El
+ .Sh RETURN VALUE
+-.Rv -std acl_set_file
++.Rv -std acl_set_file acl_set_file_at
+ .Sh ERRORS
+ If any of the following conditions occur, the
+ .Fn acl_set_file
+-function returns
++and
++.Fn acl_set_file_at
++functions return
+ .Li -1
+-and sets
++and set
+ .Va errno
+ to the corresponding value:
+ .Bl -tag -width Er
+@@ -100,6 +182,14 @@ Argument
+ .Va type
+ specifies a type of ACL that cannot be associated with
+ .Va path_p .
++.It Bq Er EBADF
++The argument
++.Va path_p
++is relative but the argument
++.Va dirfd
++is neither
++.Dv AT_FDCWD
++nor a valid file descriptor.
+ .It Bq Er EINVAL
+ The argument
+ .Va acl
+@@ -111,13 +201,22 @@ can obtain.
+ .Pp
+ The
+ .Va type
+-parameter is not ACL_TYPE_ACCESS or ACL_TYPE_DEFAULT.
++parameter is not
++.Dv ACL_TYPE_ACCESS
++or
++.Dv ACL_TYPE_DEFAULT .
+ .Pp
+ The
+ .Va type
+-parameter is ACL_TYPE_DEFAULT, but the file referred to by
++parameter is
++.Dv ACL_TYPE_DEFAULT ,
++but the file referred to by
+ .Va path_p
+ is not a directory.
++.Pp
++An invalid flag was specified in the
++.Va at_flags
++argument.
+ .It Bq Er ENAMETOOLONG
+ The length of the argument
+ .Va path_p
+@@ -130,7 +229,21 @@ points to an empty string.
+ The directory or file system that would contain the new ACL cannot be extended or the file system is out of file allocation resources.
+ .It Bq Er ENOTDIR
+ A component of the path prefix is not a directory.
++.Pp
++The argument
++.Va path_p
++is relative and the argument
++.Va dirfd
++is a file descriptor referring to a file other than a directory.
+ .It Bq Er ENOTSUP
++The argument
++.Va at_flags
++includes the flag
++.Dv AT_SYMLINK_NOFOLLOW
++and
++.Va path_p
++is a symbolic link.
++.Pp
+ The file identified by
+ .Va path_p 
+ cannot be associated with the ACL because the file system on which the file
+@@ -149,12 +262,18 @@ when the
+ .Va acl
+ parameter refers to an empty ACL and the
+ .Va type
+-parameter is ACL_TYPE_DEFAULT is an extension in the Linux implementation, in order that all values returned by
++parameter is
++.Dv ACL_TYPE_DEFAULT
++is an extension in the Linux implementation, in order that all values returned by
+ .Fn acl_get_file
+ can be passed to
+ .Fn acl_set_file .
+ The POSIX.1e function for removing a default ACL is
+ .Fn acl_delete_def_file .
++.Pp
++Function
++.Fn acl_get_file_at
++is a Linux specific extension.
+ .Sh SEE ALSO
+ .Xr acl_delete_def_file 3 ,
+ .Xr acl_get_file 3 ,
+Index: acl/man/man3/acl_set_file_at.3
+===================================================================
+--- /dev/null
++++ acl/man/man3/acl_set_file_at.3
+@@ -0,0 +1 @@
++.so man3/acl_set_file.3
+Index: acl/man/man5/acl.5
+===================================================================
+--- acl.orig/man/man5/acl.5
++++ acl/man/man5/acl.5
+@@ -21,7 +21,7 @@
+ .\" License along with this manual.  If not, see
+ .\" <http://www.gnu.org/licenses/>.
+ .\"
+-.Dd March 23, 2002
++.Dd June 5, 2026
+ .Dt ACL 5
+ .Os "Linux ACL"
+ .Sh NAME
+@@ -462,7 +462,7 @@ For further details, see
+ .Ss POSIX 1003.1e FUNCTIONS BY AVAILABILITY
+ The first group of functions is supported on most systems with POSIX-like
+ access control lists, while the second group is supported on fewer systems.
+-For applications that will be ported the second group is best avoided.
++For applications that will be ported, the second group is best avoided.
+ .Pp
+ .Xr acl_delete_def_file 3 ,
+ .Xr acl_dup 3 ,
+@@ -498,14 +498,18 @@ These non-portable extensions are availa
+ .Pp
+ .Xr acl_check 3 ,
+ .Xr acl_cmp 3 ,
++.Xr acl_delete_def_file_at 3 ,
+ .Xr acl_entries 3 ,
+ .Xr acl_equiv_mode 3 ,
+ .Xr acl_error 3 ,
+ .Xr acl_extended_fd 3 ,
+ .Xr acl_extended_file 3 ,
++.Xr acl_extended_file_at 3 ,
+ .Xr acl_extended_file_nofollow 3 ,
+ .Xr acl_from_mode 3 ,
++.Xr acl_get_file_at 3 ,
+ .Xr acl_get_perm 3 ,
++.Xr acl_set_file_at 3 ,
+ .Xr acl_to_any_text 3
+ .Sh AUTHOR
+ Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>

--- a/debian/patches/backport-0007-CVE-2026-54370.patch
+++ b/debian/patches/backport-0007-CVE-2026-54370.patch
@@ -1,0 +1,417 @@
+From 39b00348f5911e4e5937ddfb079cc456288b3cd3 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Tue, 9 Jun 2026 08:42:16 +0200
+Subject: [PATCH] Add the new walk_tree helper
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ include/Makemodule.am |   1 +
+ include/walk_tree.h   |  40 +++++
+ libmisc/Makemodule.am |   1 +
+ libmisc/walk_tree.c   | 340 ++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 382 insertions(+)
+ create mode 100644 include/walk_tree.h
+ create mode 100644 libmisc/walk_tree.c
+
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -6,6 +6,7 @@ noinst_HEADERS += \
+ 	include/misc.h \
+ 	include/old_walk_tree.h \
+ 	include/visibility-hidden.h \
++	include/walk_tree.h \
+ 	include/xattrat.h \
+ 	include/xattrat_compat.h
+ 
+Index: acl/include/walk_tree.h
+===================================================================
+--- /dev/null
++++ acl/include/walk_tree.h
+@@ -0,0 +1,40 @@
++/*
++  File: walk_tree.h
++
++  Copyright (C) 2007-2026 Andreas Gruenbacher <a.gruenbacher@computer.org>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#ifndef __WALK_TREE_H
++#define __WALK_TREE_H
++
++enum walk_flags {
++	WALK_TREE_RECURSIVE = 0x01,
++	WALK_TREE_PHYSICAL = 0x02,
++	WALK_TREE_LOGICAL = 0x04,
++	WALK_TREE_ONE_FILESYSTEM = 0x08,
++
++	WALK_TREE_TOPLEVEL = 0x100,
++	WALK_TREE_FAILED = 0x200,
++};
++
++struct stat;
++
++extern int walk_tree(const char *pathname, enum walk_flags walk_flags,
++		     int (*func)(int, const char *, const char *,
++				 unsigned char, enum walk_flags, void *),
++		     void *arg);
++
++#endif
+Index: acl/libmisc/walk_tree.c
+===================================================================
+--- /dev/null
++++ acl/libmisc/walk_tree.c
+@@ -0,0 +1,340 @@
++/*
++  File: walk_tree.c
++
++  Copyright (C) 2007-2026 Andreas Gruenbacher <a.gruenbacher@computer.org>
++
++  This library is free software; you can redistribute it and/or
++  modify it under the terms of the GNU Lesser General Public
++  License as published by the Free Software Foundation; either
++  version 2.1 of the License, or (at your option) any later version.
++
++  This library is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public
++  License along with this library; if not, see <https://www.gnu.org/licenses/>.
++*/
++
++#include "config.h"
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <sys/time.h>
++#include <sys/resource.h>
++#include <dirent.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <errno.h>
++
++#include "walk_tree.h"
++
++struct dir_stack_entry {
++	struct dir_stack_entry *parent;
++	DIR *stream;
++	long pos;
++	dev_t dev;
++	ino_t ino;
++};
++
++struct dir_hash_entry {
++	struct dir_hash_entry *next;
++	dev_t dev;
++	ino_t ino;
++};
++
++#define DIR_HASH_SIZE 128
++
++struct walk_tree_args {
++	enum walk_flags walk_flags;
++	int (*func)(int, const char *, const char *, unsigned char,
++		    enum walk_flags, void *);
++	void *arg;
++	int depth;
++	unsigned int num_dir_handles;
++	dev_t dev;
++	struct dir_hash_entry **dir_hash;
++};
++
++static int dir_visited(struct dir_stack_entry *entry, dev_t dev, ino_t ino)
++{
++	while (entry) {
++		if (entry->dev == dev && entry->ino == ino)
++			  return 1;
++		entry = entry->parent;
++	}
++	return 0;
++}
++
++static unsigned int dir_hash(dev_t dev, ino_t ino)
++{
++	return (dev ^ ino) % DIR_HASH_SIZE;
++}
++
++static int dir_hash_insert_unique(struct walk_tree_args *args, struct stat *st)
++{
++	unsigned int bucket = dir_hash(st->st_dev, st->st_ino);
++	struct dir_hash_entry *entry;
++
++	if (!args->dir_hash) {
++		/* allocate the directory hash table */
++		args->dir_hash = calloc(DIR_HASH_SIZE, sizeof(*args->dir_hash));
++		if (!args->dir_hash)
++			return -1;
++	}
++
++	entry = args->dir_hash[bucket];
++	while (entry) {
++		if (entry->dev == st->st_dev && entry->ino == st->st_ino)
++			return 1;
++		entry = entry->next;
++	}
++
++	entry = malloc(sizeof(*entry));
++	if (!entry)
++		return -1;
++
++	entry->dev = st->st_dev;
++	entry->ino = st->st_ino;
++	entry->next = args->dir_hash[bucket];
++	args->dir_hash[bucket] = entry;
++	return 0;
++}
++
++static char *new_dirname(const char *dirname, const char *pathname)
++{
++	size_t dirlen, pathlen;
++	char *newname, *n;
++	int need_slash;
++
++	if (*dirname == '\0' && *pathname == '.' &&
++	    (*(pathname+1) == '/' || *(pathname+1) == '\0')) {
++		pathname++;
++		while (*pathname == '/')
++			pathname++;
++	}
++
++	dirlen = strlen(dirname);
++	pathlen = strlen(pathname);
++	need_slash = (pathlen > 0 && pathname[pathlen - 1] != '/');
++	n = newname = malloc(dirlen + pathlen + need_slash + 1);
++	if (newname == NULL)
++		return NULL;
++	memcpy(n, dirname, dirlen);
++	n += dirlen;
++	memcpy(n, pathname, pathlen);
++	n += pathlen;
++	if (need_slash)
++		*n++ = '/';
++	*n++ = '\0';
++	return newname;
++}
++
++static int walk_tree_rec(int dirfd, const char *dirname, const char *pathname,
++			 unsigned char dirtype, struct walk_tree_args *args,
++			 struct dir_stack_entry *parent_dir)
++{
++	enum walk_flags walk_flags = args->walk_flags;
++	struct dir_stack_entry this_dir = {
++		.parent = parent_dir,
++	};
++	int follow;
++	struct stat st;
++	char *mydirname = NULL;
++	int dir_open_flags;
++	int fd = -1;
++	struct dirent *entry;
++	int err = 0;
++
++	if (args->depth == 0)
++		walk_flags |= WALK_TREE_TOPLEVEL;
++
++	follow = (walk_flags & WALK_TREE_LOGICAL) ||
++		 (!(walk_flags & WALK_TREE_PHYSICAL) && !args->depth);
++
++	if (!(walk_flags & WALK_TREE_RECURSIVE) ||
++	    (dirtype != DT_UNKNOWN &&
++	     dirtype != DT_DIR &&
++	     (dirtype != DT_LNK ||
++	      ((walk_flags & WALK_TREE_PHYSICAL) &&
++	       !(walk_flags & WALK_TREE_TOPLEVEL)))))
++		goto visit_this;
++
++	if (args->num_dir_handles == 0) {
++		struct dir_stack_entry *top;
++
++close_another_parent:
++		/* Close the topmost parent directory handle still open. */
++		top = parent_dir;
++		if (!top || !top->stream) {
++			errno = ENFILE;
++			goto fail;
++		}
++		while (top->parent && top->parent->stream)
++			top = top->parent;
++		top->pos = telldir(top->stream);
++		closedir(top->stream);
++		top->stream = NULL;
++		args->num_dir_handles++;
++	}
++
++	dir_open_flags = O_RDONLY | O_DIRECTORY | (follow ? 0 : O_NOFOLLOW);
++	fd = openat(dirfd, pathname, dir_open_flags);
++	if (fd == -1) {
++		if (errno == ENOTDIR || errno == ENOENT || errno == ELOOP)
++			goto visit_this;
++		if (errno != ENFILE)
++			goto fail;
++		/* Ran out of file descriptors. */
++		args->num_dir_handles = 0;
++		goto close_another_parent;
++	}
++	args->num_dir_handles--;
++	if (dirtype == DT_UNKNOWN && !follow)
++		dirtype = DT_DIR;
++
++	if (fstat(fd, &st) == -1)
++		goto fail;
++	if (walk_flags & WALK_TREE_ONE_FILESYSTEM) {
++		if (args->dev == 0)
++			args->dev = st.st_dev;
++		else if (st.st_dev != args->dev)
++			goto dir_visited;
++	}
++
++	if (walk_flags & WALK_TREE_LOGICAL) {
++		if (dir_visited(parent_dir, st.st_dev, st.st_ino))
++			goto dir_visited;
++		this_dir.dev = st.st_dev;
++		this_dir.ino = st.st_ino;
++	} else {
++		int ret = dir_hash_insert_unique(args, &st);
++		if (ret == 1)
++			goto dir_visited;
++		if (ret == -1)
++			goto fail;
++	}
++	goto visit_this;
++
++dir_visited:
++	close(fd);
++	fd = -1;
++	if (dirtype == DT_UNKNOWN) {
++		if (fstatat(dirfd, pathname, &st, AT_SYMLINK_NOFOLLOW) == -1)
++			goto fail;
++		dirtype = IFTODT(st.st_mode);
++	}
++	if (dirtype == DT_DIR)
++		goto out;
++
++visit_this:
++	err += args->func(dirfd, dirname, pathname, dirtype,
++			  walk_flags, args->arg);
++
++	if (fd == -1)
++		goto out;
++	this_dir.stream = fdopendir(fd);
++	if (this_dir.stream == NULL)
++		goto fail;
++
++	mydirname = new_dirname(dirname, pathname);
++	if (mydirname == NULL)
++		goto fail;
++
++	args->depth++;
++	while ((entry = readdir(this_dir.stream)) != NULL) {
++		if (!strcmp(entry->d_name, ".") ||
++		    !strcmp(entry->d_name, ".."))
++			continue;
++
++		err += walk_tree_rec(fd, mydirname, entry->d_name,
++				     entry->d_type, args, &this_dir);
++
++		if (!this_dir.stream) {
++			/* Reopen the directory handle. */
++			fd = openat(dirfd, pathname, dir_open_flags);
++			if (fd == -1)
++				goto fail_depth;
++			args->num_dir_handles--;
++			this_dir.stream = fdopendir(fd);
++			if (!this_dir.stream)
++				goto fail_depth;
++			seekdir(this_dir.stream, this_dir.pos);
++		}
++	}
++	args->depth--;
++
++	if (closedir(this_dir.stream) != 0) {
++		this_dir.stream = NULL;
++		goto fail;
++	}
++	this_dir.stream = NULL;
++
++out:
++	free(mydirname);
++	if (this_dir.stream) {
++		closedir(this_dir.stream);
++		args->num_dir_handles++;
++		fd = -1;
++	}
++	if (fd != -1) {
++		close(fd);
++		args->num_dir_handles++;
++	}
++	return err;
++
++fail:
++	err += args->func(dirfd, dirname, pathname, dirtype,
++			  walk_flags | WALK_TREE_FAILED, args->arg);
++	goto out;
++
++fail_depth:
++	args->depth--;
++	goto fail;
++}
++
++/*
++ * If (walk_flags & WALK_TREE_PHYSICAL), do not traverse symlinks.
++ * If (walk_flags & WALK_TREE_LOGICAL), traverse all symlinks.
++ * Otherwise, traverse only top-level symlinks.
++ */
++int walk_tree(const char *pathname, enum walk_flags walk_flags,
++	      int (*func)(int, const char *, const char *, unsigned char,
++			  enum walk_flags, void *),
++	      void *arg)
++{
++	struct walk_tree_args args = {
++		.walk_flags = walk_flags,
++		.func = func,
++		.arg = arg,
++	};
++	struct rlimit rlimit;
++	int err;
++
++	/* number of directory file descriptors to keep open at a time */
++	if (getrlimit(RLIMIT_NOFILE, &rlimit) != 0)
++		rlimit.rlim_cur = 0;
++	args.num_dir_handles = rlimit.rlim_cur / 4 + 1;
++
++	err = walk_tree_rec(AT_FDCWD, "", pathname, DT_UNKNOWN, &args, NULL);
++
++	if (args.dir_hash) {
++		/* destroy the directory hash table */
++		int n;
++
++		for (n = 0; n < DIR_HASH_SIZE; n++) {
++			struct dir_hash_entry *entry = args.dir_hash[n];
++			while (entry) {
++				struct dir_hash_entry *next = entry->next;
++				free(entry);
++				entry = next;
++			}
++		}
++		free(args.dir_hash);
++	}
++
++	return err;
++}

--- a/debian/patches/backport-0008-CVE-2026-54369.patch
+++ b/debian/patches/backport-0008-CVE-2026-54369.patch
@@ -1,0 +1,101 @@
+From 170dbd3beff9bd5bdab3f72db1a04bf282f6087c Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Wed, 17 Jun 2026 17:16:26 +0200
+Subject: [PATCH] man pages: Clarify symlink following behavior
+
+In the acl_delete_def_file(), acl_extended_file(), acl_get_file(), and
+acl_set_file() manual pages, clarify that those functions follow symlinks;
+before this change, that wasn't very obvious.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ man/man3/acl_delete_def_file.3 |  7 ++++++-
+ man/man3/acl_extended_file.3   |  7 ++++++-
+ man/man3/acl_get_file.3        | 10 +++++++++-
+ man/man3/acl_set_file.3        |  7 ++++++-
+ 4 files changed, 27 insertions(+), 4 deletions(-)
+
+Index: acl/man/man3/acl_delete_def_file.3
+===================================================================
+--- acl.orig/man/man3/acl_delete_def_file.3
++++ acl/man/man3/acl_delete_def_file.3
+@@ -46,8 +46,13 @@ Linux Access Control Lists library (liba
+ .Sh DESCRIPTION
+ The
+ .Fn acl_delete_def_file
+-function deletes a default ACL from the directory whose pathname is pointed to by the argument
++function deletes a default ACL from the directory whose pathname is given in
+ .Va path_p .
++If
++.Va path_p
++is a symbolic link,
++.Fn acl_delete_def_file
++operates on the directory the link refers to.
+ .Pp
+ The effective user ID of the process must match the owner of the file or
+ directory or the process must have the CAP_FOWNER capability for the
+Index: acl/man/man3/acl_extended_file.3
+===================================================================
+--- acl.orig/man/man3/acl_extended_file.3
++++ acl/man/man3/acl_extended_file.3
+@@ -53,13 +53,18 @@ The
+ .Fn acl_extended_file
+ function returns
+ .Li 1
+-if the file or directory referred to by the argument
++if the file or directory whose pathname is given in
+ .Va path_p
+ is associated with an extended access ACL, or if the directory referred to by
+ .Va path_p
+ is associated with a default ACL. The function returns
+ .Li 0
+ if the file has neither an extended access ACL nor a default ACL.
++If
++.Va path_p
++is a symbolic link,
++.Fn acl_extended_file
++returns information about the file or directory the link refers to.
+ .Pp
+ An extended ACL is an ACL that contains entries other than the three
+ required entries of tag types ACL_USER_OBJ, ACL_GROUP_OBJ and ACL_OTHER.
+Index: acl/man/man3/acl_get_file.3
+===================================================================
+--- acl.orig/man/man3/acl_get_file.3
++++ acl/man/man3/acl_get_file.3
+@@ -48,8 +48,16 @@ Linux Access Control Lists library (liba
+ .Sh DESCRIPTION
+ The
+ .Fn acl_get_file
+-function retrieves the access ACL associated with a file or directory, or the default ACL associated with a directory. The pathname for the file or directory is pointed to by the argument
++function retrieves the access ACL associated with a file or directory, or the
++default ACL associated with a directory. The pathname for the file or directory
++is given in the argument
+ .Va path_p .
++If
++.Va path_p
++is a symbolic link,
++.Fn acl_get_file
++returns information about the file or directory the link refers to.
++.Pp
+ The ACL is placed into working storage and
+ .Fn acl_get_file
+ returns a pointer to that storage.
+Index: acl/man/man3/acl_set_file.3
+===================================================================
+--- acl.orig/man/man3/acl_set_file.3
++++ acl/man/man3/acl_set_file.3
+@@ -52,8 +52,13 @@ The
+ .Fn acl_set_file
+ function associates an access ACL with a file or directory, or
+ associates a default ACL with a directory. The pathname for the file or
+-directory is pointed to by the argument
++directory is given in the argument
+ .Va path_p .
++If
++.Va path_p
++is a symbolic link,
++.Fn acl_set_file
++operates on the file or directory the link refers to.
+ .Pp
+ The effective user ID of the process must match the owner of the file or
+ directory or the process must have the CAP_FOWNER capability for the

--- a/debian/patches/backport-0008-CVE-2026-54370.patch
+++ b/debian/patches/backport-0008-CVE-2026-54370.patch
@@ -1,0 +1,101 @@
+From 49dd328376012cc4db12af630a32c97a49841318 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Fri, 5 Jun 2026 22:15:53 +0200
+Subject: [PATCH] getfacl: Get rid of some unnecessary file handle passing
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ tools/getfacl.c | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+Index: acl/tools/getfacl.c
+===================================================================
+--- acl.orig/tools/getfacl.c
++++ acl/tools/getfacl.c
+@@ -252,7 +252,7 @@ static void apply_mask(char *perm, const
+ 	}
+ }
+ 
+-static int show_line(FILE *stream, struct name_list **acl_names,  acl_t acl,
++static int show_line(struct name_list **acl_names,  acl_t acl,
+               acl_entry_t *acl_ent, const char *acl_mask,
+               struct name_list **dacl_names, acl_t dacl,
+ 	      acl_entry_t *dacl_ent, const char *dacl_mask)
+@@ -309,10 +309,10 @@ static int show_line(FILE *stream, struc
+ 			apply_mask(dacl_perm, dacl_mask);
+ 	}
+ 
+-	fprintf(stream, "%-5s  %*s  %*s  %*s\n",
+-	        tag, -names_width, name,
+-	        -(int)ACL_PERMS, acl_perm,
+-		-(int)ACL_PERMS, dacl_perm);
++	printf("%-5s  %*s  %*s  %*s\n",
++	       tag, -names_width, name,
++	       -(int)ACL_PERMS, acl_perm,
++	       -(int)ACL_PERMS, dacl_perm);
+ 
+ 	if (acl_names) {
+ 		acl_get_entry(acl, ACL_NEXT_ENTRY, acl_ent);
+@@ -325,7 +325,7 @@ static int show_line(FILE *stream, struc
+ 	return 0;
+ }
+ 
+-static int do_show(FILE *stream, const char *path_p, const struct stat *st,
++static int do_show(const char *path_p, const struct stat *st,
+             acl_t acl, acl_t dacl)
+ {
+ 	struct name_list *acl_names = get_list(st, acl),
+@@ -364,7 +364,7 @@ static int do_show(FILE *stream, const c
+ 		if (ret < 0)
+ 			return ret;
+ 	}
+-	fprintf(stream, "# file: %s\n", xquote(path_p, "\n\r"));
++	printf("# file: %s\n", xquote(path_p, "\n\r"));
+ 	while (acl_names != NULL || dacl_names != NULL) {
+ 		acl_tag_t acl_tag, dacl_tag;
+ 
+@@ -374,11 +374,11 @@ static int do_show(FILE *stream, const c
+ 			acl_get_tag_type(dacl_ent, &dacl_tag);
+ 
+ 		if (acl && (!dacl || acl_tag < dacl_tag)) {
+-			show_line(stream, &acl_names, acl, &acl_ent, acl_mask,
++			show_line(&acl_names, acl, &acl_ent, acl_mask,
+ 			          NULL, NULL, NULL, NULL);
+ 			continue;
+ 		} else if (dacl && (!acl || dacl_tag < acl_tag)) {
+-			show_line(stream, NULL, NULL, NULL, NULL,
++			show_line(NULL, NULL, NULL, NULL,
+ 			          &dacl_names, dacl, &dacl_ent, dacl_mask);
+ 			continue;
+ 		} else if (!dacl && !acl) {
+@@ -398,18 +398,18 @@ static int do_show(FILE *stream, const c
+ 				}
+ 				
+ 				if (acl && (!dacl || id_cmp < 0)) {
+-					show_line(stream, &acl_names, acl,
++					show_line(&acl_names, acl,
+ 					          &acl_ent, acl_mask,
+ 						  NULL, NULL, NULL, NULL);
+ 					continue;
+ 				} else if (dacl && (!acl || id_cmp > 0)) {
+-					show_line(stream, NULL, NULL, NULL,
++					show_line(NULL, NULL, NULL,
+ 					          NULL, &dacl_names, dacl,
+ 						  &dacl_ent, dacl_mask);
+ 					continue;
+ 				}
+ 			}
+-			show_line(stream, &acl_names,  acl,  &acl_ent, acl_mask,
++			show_line(&acl_names,  acl,  &acl_ent, acl_mask,
+ 				  &dacl_names, dacl, &dacl_ent, dacl_mask);
+ 		}
+ 	}
+@@ -512,7 +512,7 @@ static int do_print(const char *path_p,
+ 	}
+ 
+ 	if (opt_tabular)  {
+-		if (do_show(stdout, path_p, st, acl, default_acl) != 0)
++		if (do_show(path_p, st, acl, default_acl) != 0)
+ 			goto fail;
+ 	} else {
+ 		if (opt_comments) {

--- a/debian/patches/backport-0009-CVE-2026-54370.patch
+++ b/debian/patches/backport-0009-CVE-2026-54370.patch
@@ -1,0 +1,287 @@
+From 2ee940139e9bba5005a3d987a6daecdda909089e Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Tue, 9 Jun 2026 08:43:16 +0200
+Subject: [PATCH] harden getfacl
+
+Switch to the new walk_tree helper that uses directory file descriptors and
+relative paths instead of building full pathnames.  On the final pathname
+component, use functions that only follow symlinks when requested (stat() ->
+fstatat(), acl_get_file() -> acl_get_file_at()).  This prevents getfacl from
+accidentally following a symlink an attacker may have planted.
+
+A notable change is that commands like 'getfacl -P symlink' will now fail with
+an ELOOP error ("Too many levels of symbolic links").  Previously, command-line
+arguments that refer to symbolic links were silently ignored in -P (--physical)
+mode.
+
+Fixes: CVE-2026-54370 ("acl < 2.4.0 TOCTOU Symlink Traversal via getfacl/setfacl")
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ tools/getfacl.c | 113 ++++++++++++++++++++++++++++++------------------
+ 1 file changed, 71 insertions(+), 42 deletions(-)
+
+Index: acl/tools/getfacl.c
+===================================================================
+--- acl.orig/tools/getfacl.c
++++ acl/tools/getfacl.c
+@@ -4,6 +4,7 @@
+ 
+   Copyright (C) 1999-2002
+   Andreas Gruenbacher, <andreas.gruenbacher@gmail.com>
++  Copyright 2026 Andreas Gruenbacher <andreas.gruenbacher@gmail.com>
+  	
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+@@ -30,6 +31,7 @@
+ #include <limits.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <fcntl.h>
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <dirent.h>
+@@ -37,7 +39,7 @@
+ #include <getopt.h>
+ #include "misc.h"
+ #include "user_group.h"
+-#include "old_walk_tree.h"
++#include "walk_tree.h"
+ 
+ #define POSIXLY_CORRECT_STR "POSIXLY_CORRECT"
+ 
+@@ -70,7 +72,7 @@ static const struct option long_options[
+ const char *progname;
+ static const char *cmd_line_options;
+ 
+-static int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
++static enum walk_flags walk_flags = 0;
+ static int opt_print_acl;
+ static int opt_print_default_acl;
+ static int opt_strip_leading_slash = 1;
+@@ -325,8 +327,8 @@ static int show_line(struct name_list **
+ 	return 0;
+ }
+ 
+-static int do_show(const char *path_p, const struct stat *st,
+-            acl_t acl, acl_t dacl)
++static int do_show(const char *fullname, const struct stat *st,
++		   acl_t acl, acl_t dacl)
+ {
+ 	struct name_list *acl_names = get_list(st, acl),
+ 	                 *first_acl_name = acl_names;
+@@ -364,7 +366,7 @@ static int do_show(const char *path_p, c
+ 		if (ret < 0)
+ 			return ret;
+ 	}
+-	printf("# file: %s\n", xquote(path_p, "\n\r"));
++	printf("# file: %s\n", xquote(fullname, "\n\r"));
+ 	while (acl_names != NULL || dacl_names != NULL) {
+ 		acl_tag_t acl_tag, dacl_tag;
+ 
+@@ -425,11 +427,11 @@ static int do_show(const char *path_p, c
+  * of the file PATH_P.
+  */
+ static acl_t
+-acl_get_file_mode(const char *path_p)
++acl_get_from_file_mode_at(int dirfd, const char *pathname, int at_flags)
+ {
+ 	struct stat st;
+ 
+-	if (stat(path_p, &st) != 0)
++	if (fstatat(dirfd, pathname, &st, at_flags) != 0)
+ 		return NULL;
+ 	return acl_from_mode(st.st_mode);
+ }
+@@ -446,15 +448,32 @@ flagstr(mode_t mode)
+ 	return str;
+ }
+ 
+-static int do_print(const char *path_p, const struct stat *st, int walk_flags, void *unused)
++static int do_print(int dirfd, const char *dirname, const char *pathname,
++		    unsigned char dirtype, enum walk_flags walk_flags,
++		    void *unused)
+ {
++	static char *__fullname;
++	const char *fullname;
+ 	const char *default_prefix = NULL;
+ 	acl_t acl = NULL, default_acl = NULL;
++	struct stat st;
++	int at_flags;
+ 	int error = 0;
+ 
++	if (*dirname) {
++		free(__fullname);
++		__fullname = NULL;
++		if (asprintf(&__fullname, "%s%s", dirname, pathname) == -1) {
++			fprintf(stderr, "%s: %s", progname, strerror(errno));
++			return 1;
++		}
++		fullname = __fullname;
++	} else
++		fullname = pathname;
++
+ 	if (walk_flags & WALK_TREE_FAILED) {
+-		fprintf(stderr, "%s: %s: %s\n", progname, xquote(path_p, "\n\r"),
+-			strerror(errno));
++		fprintf(stderr, "%s: %s: %s\n", progname,
++			xquote(fullname, "\n\r"), strerror(errno));
+ 		return 1;
+ 	}
+ 
+@@ -463,21 +482,37 @@ static int do_print(const char *path_p,
+ 	 * skip symlinks altogether, and when doing a half-logical walk, we
+ 	 * skip all non-toplevel symlinks. 
+ 	 */
+-	if ((walk_flags & WALK_TREE_SYMLINK) &&
+-	    ((walk_flags & WALK_TREE_PHYSICAL) ||
+-	     !(walk_flags & (WALK_TREE_TOPLEVEL | WALK_TREE_LOGICAL))))
+-		return 0;
++	at_flags = AT_SYMLINK_NOFOLLOW;
++	if ((walk_flags & WALK_TREE_LOGICAL) ||
++	    ((walk_flags & WALK_TREE_TOPLEVEL) &&
++	     !(walk_flags & WALK_TREE_PHYSICAL)))
++	       at_flags = 0;
++
++	if (dirtype == DT_LNK && (at_flags & AT_SYMLINK_NOFOLLOW))
++		goto cleanup;
++
++	if (fstatat(dirfd, pathname, &st, at_flags) != 0)
++		goto fail;
++	if (S_ISLNK(st.st_mode)) {
++		if (!(walk_flags & WALK_TREE_TOPLEVEL))
++			goto cleanup;
++		errno = ELOOP;
++		goto fail;
++	}
+ 
+ 	if (opt_print_acl) {
+-		acl = acl_get_file(path_p, ACL_TYPE_ACCESS);
++		acl = acl_get_file_at(dirfd, pathname, at_flags,
++				      ACL_TYPE_ACCESS);
+ 		if (acl == NULL && (errno == ENOSYS || errno == ENOTSUP))
+-			acl = acl_get_file_mode(path_p);
++			acl = acl_get_from_file_mode_at(dirfd, pathname,
++							at_flags);
+ 		if (acl == NULL)
+ 			goto fail;
+ 	}
+ 
+-	if (opt_print_default_acl && S_ISDIR(st->st_mode)) {
+-		default_acl = acl_get_file(path_p, ACL_TYPE_DEFAULT);
++	if (opt_print_default_acl && S_ISDIR(st.st_mode)) {
++		default_acl = acl_get_file_at(dirfd, pathname, at_flags,
++					      ACL_TYPE_DEFAULT);
+ 		if (default_acl == NULL) {
+ 			if (errno != ENOSYS && errno != ENOTSUP)
+ 				goto fail;
+@@ -495,34 +530,30 @@ static int do_print(const char *path_p,
+ 		default_prefix = "default:";
+ 
+ 	if (opt_strip_leading_slash) {
+-		if (*path_p == '/') {
++		if (*fullname == '/') {
+ 			if (!absolute_warning) {
+ 				fprintf(stderr, _("%s: Removing leading "
+ 					"'/' from absolute path names\n"),
+-				        progname);
++					progname);
+ 				absolute_warning = 1;
+ 			}
+-			while (*path_p == '/')
+-				path_p++;
+-		} else if (*path_p == '.' && *(path_p+1) == '/')
+-			while (*++path_p == '/')
+-				/* nothing */ ;
+-		if (*path_p == '\0')
+-			path_p = ".";
++			while (*fullname == '/')
++				fullname++;
++		}
+ 	}
+ 
+ 	if (opt_tabular)  {
+-		if (do_show(path_p, st, acl, default_acl) != 0)
++		if (do_show(fullname, &st, acl, default_acl) != 0)
+ 			goto fail;
+ 	} else {
+ 		if (opt_comments) {
+-			printf("# file: %s\n", xquote(path_p, "\n\r"));
++			printf("# file: %s\n", xquote(fullname, "\n\r"));
+ 			printf("# owner: %s\n",
+-			       xquote(user_name(st->st_uid, opt_numeric), " \t\n\r"));
++			       xquote(user_name(st.st_uid, opt_numeric), " \t\n\r"));
+ 			printf("# group: %s\n",
+-			       xquote(group_name(st->st_gid, opt_numeric), " \t\n\r"));
+-			if ((st->st_mode & (S_ISVTX | S_ISUID | S_ISGID)) && !posixly_correct)
+-				printf("# flags: %s\n", flagstr(st->st_mode));
++			       xquote(group_name(st.st_gid, opt_numeric), " \t\n\r"));
++			if ((st.st_mode & (S_ISVTX | S_ISUID | S_ISGID)) && !posixly_correct)
++				printf("# flags: %s\n", flagstr(st.st_mode));
+ 		}
+ 		if (acl != NULL) {
+ 			char *acl_text = acl_to_any_text(acl, NULL, '\n',
+@@ -559,8 +590,7 @@ cleanup:
+ 	return error;
+ 
+ fail:
+-	fprintf(stderr, "%s: %s: %s\n", progname, xquote(path_p, "\n\r"),
+-		strerror(errno));
++	fprintf(stderr, "%s: %s: %s\n", progname, fullname, strerror(errno));
+ 	error = -1;
+ 	goto cleanup;
+ }
+@@ -591,7 +621,7 @@ static void help(void)
+ "  -P, --physical          physical walk, do not follow symbolic links\n"
+ "  -t, --tabular           use tabular output format\n"
+ "  -n, --numeric           print numeric user/group identifiers\n"
+-"      --one-file-system   skip files on different filesystems\n"
++"      --one-file-system   don't descend into directories on other filesystems\n"
+ "  -p, --absolute-names    don't strip leading '/' in pathnames\n"));
+ 	}
+ #endif
+@@ -668,7 +698,7 @@ int main(int argc, char *argv[])
+ 			case 'L':  /* follow all symlinks */
+ 				if (posixly_correct)
+ 					goto synopsis;
+-				walk_flags |= WALK_TREE_LOGICAL | WALK_TREE_DEREFERENCE;
++				walk_flags |= WALK_TREE_LOGICAL;
+ 				walk_flags &= ~WALK_TREE_PHYSICAL;
+ 				break;
+ 
+@@ -676,8 +706,7 @@ int main(int argc, char *argv[])
+ 				if (posixly_correct)
+ 					goto synopsis;
+ 				walk_flags |= WALK_TREE_PHYSICAL;
+-				walk_flags &= ~(WALK_TREE_LOGICAL | WALK_TREE_DEREFERENCE |
+-						WALK_TREE_DEREFERENCE_TOPLEVEL);
++				walk_flags &= ~WALK_TREE_LOGICAL;
+ 				break;
+ 
+ 			case 's':  /* skip files with only base entries */
+@@ -715,7 +744,7 @@ int main(int argc, char *argv[])
+ 				help();
+ 				return 0;
+ 
+-			case ':':  /* option missing */
++			case ':':  /* argument missing */
+ 			case '?':  /* unknown option */
+ 			default:
+ 				goto synopsis;
+@@ -738,7 +767,7 @@ int main(int argc, char *argv[])
+ 				if (*line == '\0')
+ 					continue;
+ 
+-				had_errors += old_walk_tree(line, walk_flags, 0,
++				had_errors += walk_tree(line, walk_flags,
+ 							do_print, NULL);
+ 			}
+ 			if (!feof(stdin)) {
+@@ -747,7 +776,7 @@ int main(int argc, char *argv[])
+ 				had_errors++;
+ 			}
+ 		} else
+-			had_errors += old_walk_tree(argv[optind], walk_flags, 0,
++			had_errors += walk_tree(argv[optind], walk_flags,
+ 						do_print, NULL);
+ 		optind++;
+ 	} while (optind < argc);

--- a/debian/patches/backport-0010-CVE-2026-54370.patch
+++ b/debian/patches/backport-0010-CVE-2026-54370.patch
@@ -1,0 +1,392 @@
+From 2c03ceefa0610d551d9cc089ce0a404cbe2d34b4 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Tue, 9 Jun 2026 08:43:46 +0200
+Subject: [PATCH] harden setfacl
+
+Switch to the new walk_tree helper that uses directory file descriptors and
+relative paths instead of building full pathnames.  On the final pathname
+component, use functions that only follow symlinks when requested (stat() ->
+fstatat(), acl_get_file() -> acl_get_file_at(), chmod() -> fchmodat(),
+acl_set_file() -> acl_set_file_at(), acl_delete_def_file() ->
+acl_delete_def_file_at()).  This prevents setfacl from accidentally following a
+symlink an attacker may have planted.
+
+A notable change is that commands like 'setfacl -P ... symlink' will now fail
+with an ELOOP error ("Too many levels of symbolic links").  Previously,
+command-line arguments that refer to symbolic links were silently ignored in
+-P (--physical) mode.
+
+(The --restore option is hardened in a separate patch.)
+
+Fixes: CVE-2026-54370 ("acl < 2.4.0 TOCTOU Symlink Traversal via getfacl/setfacl")
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ man/man1/setfacl.1 |  1 -
+ tools/do_set.c     | 98 +++++++++++++++++++++++++++++++---------------
+ tools/do_set.h     |  5 ++-
+ tools/setfacl.c    | 18 ++++-----
+ 4 files changed, 79 insertions(+), 43 deletions(-)
+
+Index: acl/man/man1/setfacl.1
+===================================================================
+--- acl.orig/man/man1/setfacl.1
++++ acl/man/man1/setfacl.1
+@@ -130,7 +130,6 @@ This option cannot be mixed with `\-\-re
+ .TP 4
+ .I \-P, \-\-physical
+ Physical walk, do not follow symbolic links to directories.
+-This also skips symbolic link arguments.
+ Only effective in combination with \-R.
+ This option cannot be mixed with `\-\-restore'.
+ .TP 4
+Index: acl/tools/do_set.c
+===================================================================
+--- acl.orig/tools/do_set.c
++++ acl/tools/do_set.c
+@@ -31,13 +31,14 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
++#include <fcntl.h>
+ #include <dirent.h>
+ #include <ftw.h>
+ #include "misc.h"
+ #include "sequence.h"
+ #include "do_set.h"
+ #include "parse.h"
+-#include "old_walk_tree.h"
++#include "walk_tree.h"
+ 
+ 
+ static acl_entry_t
+@@ -119,7 +120,7 @@ clone_entry(
+ static void
+ print_test(
+ 	FILE *file,
+-	const char *path_p,
++	const char *fullname,
+ 	const struct stat *st,
+ 	const acl_t acl,
+ 	const acl_t default_acl)
+@@ -129,7 +130,7 @@ print_test(
+ 	acl_text = acl_to_any_text(acl, NULL, ',', TEXT_ABBREVIATE);
+ 	default_acl_text =
+ 		acl_to_any_text(default_acl, "d:", ',', TEXT_ABBREVIATE);
+-	fprintf(file, "%s: %s,%s\n", path_p,
++	fprintf(file, "%s: %s,%s\n", fullname,
+ 		acl_text ? acl_text : "*",
+ 		default_acl_text ? default_acl_text : "*");
+ 	acl_free(acl_text);
+@@ -162,7 +163,9 @@ set_perm(
+ 
+ static int
+ retrieve_acl(
+-	const char *path_p,
++	int dirfd,
++	const char *pathname,
++	int at_flags,
+ 	acl_type_t type,
+ 	const struct stat *st,
+ 	acl_t *old_acl,
+@@ -172,7 +175,7 @@ retrieve_acl(
+ 		return 0;
+ 	*acl = NULL;
+ 	if (type == ACL_TYPE_ACCESS || S_ISDIR(st->st_mode)) {
+-		*old_acl = acl_get_file(path_p, type);
++		*old_acl = acl_get_file_at(dirfd, pathname, at_flags, type);
+ 		if (*old_acl == NULL && (errno == ENOSYS || errno == ENOTSUP)) {
+ 			if (type == ACL_TYPE_DEFAULT)
+ 				*old_acl = acl_init(0);
+@@ -246,18 +249,23 @@ remove_extended_entries(
+ 
+ 
+ #define RETRIEVE_ACL(type) do { \
+-	error = retrieve_acl(path_p, type, st, old_xacl, xacl); \
++	error = retrieve_acl(dirfd, pathname, at_flags, type, &st, \
++			     old_xacl, xacl); \
+ 	if (error) \
+ 		goto fail; \
+ 	} while(0)
+ 
+ int
+ do_set(
+-	const char *path_p,
+-	const struct stat *st,
+-	int walk_flags,
++	int dirfd,
++	const char *dirname,
++	const char *pathname,
++	unsigned char dirtype,
++	enum walk_flags walk_flags,
+ 	void *arg)
+ {
++	static char *__fullname;
++	const char *fullname;
+ 	struct do_set_args *args = arg;
+ 	acl_t old_acl = NULL, old_default_acl = NULL;
+ 	acl_t acl = NULL, default_acl = NULL;
+@@ -269,9 +277,23 @@ do_set(
+ 	char *acl_text;
+ 	int acl_modified = 0, default_acl_modified = 0;
+ 	int acl_mask_provided = 0, default_acl_mask_provided = 0;
++	struct stat st;
++	int at_flags;
++
++	if (*dirname) {
++		free(__fullname);
++		__fullname = NULL;
++		if (asprintf(&__fullname, "%s%s", dirname, pathname) == -1) {
++			fprintf(stderr, "%s: %s", progname, strerror(errno));
++			return 1;
++		}
++		fullname = __fullname;
++	} else
++		fullname = pathname;
+ 
+ 	if (walk_flags & WALK_TREE_FAILED) {
+-		fprintf(stderr, "%s: %s: %s\n", progname, path_p, strerror(errno));
++		fprintf(stderr, "%s: %s: %s\n", progname, fullname,
++			strerror(errno));
+ 		return 1;
+ 	}
+ 
+@@ -280,11 +302,23 @@ do_set(
+ 	 * skip symlinks altogether, and when doing a half-logical walk, we
+ 	 * skip all non-toplevel symlinks. 
+ 	 */
+-	if ((walk_flags & WALK_TREE_SYMLINK) &&
+-	    ((walk_flags & WALK_TREE_PHYSICAL) ||
+-	     !(walk_flags & (WALK_TREE_TOPLEVEL | WALK_TREE_LOGICAL))))
++
++	at_flags = AT_SYMLINK_NOFOLLOW;
++	if ((walk_flags & WALK_TREE_LOGICAL) ||
++	    ((walk_flags & WALK_TREE_TOPLEVEL) &&
++	     !(walk_flags & WALK_TREE_PHYSICAL)))
++		at_flags = 0;
++
++	if (dirtype == DT_LNK && (at_flags & AT_SYMLINK_NOFOLLOW))
+ 		return 0;
+ 
++	if (fstatat(dirfd, pathname, &st, at_flags) != 0)
++		goto fail;
++	if (S_ISLNK(st.st_mode)) {
++		errno = ELOOP;
++		goto fail;
++	}
++
+ 	/* Execute the commands in seq (read ACLs on demand) */
+ 	error = seq_get_cmd(args->seq, SEQ_FIRST_CMD, &cmd);
+ 	if (error == 0)
+@@ -311,7 +345,7 @@ do_set(
+ 		/* Check for `X', and replace with `x' as appropriate. */
+ 		if (perm & CMD_PERM_COND_EXECUTE) {
+ 			perm &= ~CMD_PERM_COND_EXECUTE;
+-			if (S_ISDIR(st->st_mode) || has_execute_perms(*xacl))
++			if (S_ISDIR(st.st_mode) || has_execute_perms(*xacl))
+ 				perm |= CMD_PERM_EXECUTE;
+ 		}
+ 
+@@ -402,8 +436,9 @@ do_set(
+ 		if (error > 0) {
+ 			acl_text = acl_to_any_text(acl, NULL, ',', 0);
+ 			fprintf(stderr, _("%s: %s: Malformed access ACL "
+-				"`%s': %s at entry %d\n"), progname, path_p,
+-				acl_text, acl_error(error), which_entry+1);
++				"`%s': %s at entry %d\n"), progname,
++				fullname, acl_text, acl_error(error),
++				which_entry+1);
+ 			acl_free(acl_text);
+ 			errors++;
+ 			goto cleanup;
+@@ -430,7 +465,7 @@ do_set(
+ 			acl_text = acl_to_any_text(default_acl, NULL, ',', 0);
+ 			fprintf(stderr, _("%s: %s: Malformed default ACL "
+ 			                  "`%s': %s at entry %d\n"),
+-				progname, path_p, acl_text,
++				progname, fullname, acl_text,
+ 				acl_error(error), which_entry+1);
+ 			acl_free(acl_text);
+ 			errors++;
+@@ -439,7 +474,7 @@ do_set(
+ 	}
+ 
+ 	/* Only directories can have default ACLs */
+-	if (default_acl && !S_ISDIR(st->st_mode) && (walk_flags & WALK_TREE_RECURSIVE)) {
++	if (default_acl && !S_ISDIR(st.st_mode) && (walk_flags & WALK_TREE_RECURSIVE)) {
+ 		/* In recursive mode, ignore default ACLs for files */
+ 		acl_free(default_acl);
+ 		default_acl = NULL;
+@@ -458,7 +493,7 @@ do_set(
+ 
+ 	/* update the file system */
+ 	if (opt_test) {
+-		print_test(stdout, path_p, st,
++		print_test(stdout, fullname, &st,
+ 		           acl, default_acl);
+ 		goto cleanup;
+ 	}
+@@ -468,17 +503,15 @@ do_set(
+ 
+ 		equiv_mode = acl_equiv_mode(acl, &mode);
+ 
+-		if (acl_set_file(path_p, ACL_TYPE_ACCESS, acl) != 0) {
++		if (acl_set_file_at(dirfd, pathname, at_flags, ACL_TYPE_ACCESS,
++				    acl) != 0) {
+ 			if (errno == ENOSYS || errno == ENOTSUP) {
+ 				if (equiv_mode != 0)
+ 					goto fail;
+ 				else {
+-					struct stat st;
+-
+-					if (stat(path_p, &st) != 0)
+-						goto fail;
+ 					mode |= st.st_mode & 07000;
+-					if (chmod(path_p, mode) != 0)
++					if (fchmodat(dirfd, pathname, mode,
++						     at_flags) != 0)
+ 						goto fail;
+ 				}
+ 			} else
+@@ -487,21 +520,23 @@ do_set(
+ 		args->mode = mode;
+ 	}
+ 	if (default_acl) {
+-		if (S_ISDIR(st->st_mode)) {
++		if (S_ISDIR(st.st_mode)) {
+ 			if (acl_entries(default_acl) == 0) {
+-				if (acl_delete_def_file(path_p) != 0 &&
++				if (acl_delete_def_file_at(dirfd, pathname,
++							   at_flags) != 0 &&
+ 				    errno != ENOSYS && errno != ENOTSUP)
+ 					goto fail;
+ 			} else {
+-				if (acl_set_file(path_p, ACL_TYPE_DEFAULT,
+-						 default_acl) != 0)
++				if (acl_set_file_at(dirfd, pathname, at_flags,
++						    ACL_TYPE_DEFAULT,
++						    default_acl) != 0)
+ 					goto fail;
+ 			}
+ 		} else {
+ 			if (acl_entries(default_acl) != 0) {
+ 				fprintf(stderr, _("%s: %s: Only directories "
+ 						"can have default ACLs\n"),
+-					progname, path_p);
++					progname, fullname);
+ 				errors++;
+ 				goto cleanup;
+ 			}
+@@ -522,7 +557,8 @@ cleanup:
+ 	return errors;
+ 	
+ fail:
+-	fprintf(stderr, "%s: %s: %s\n", progname, path_p, strerror(errno));
++	fprintf(stderr, "%s: %s: %s\n", progname, fullname,
++		strerror(errno));
+ 	errors++;
+ 	goto cleanup;
+ }
+Index: acl/tools/do_set.h
+===================================================================
+--- acl.orig/tools/do_set.h
++++ acl/tools/do_set.h
+@@ -23,14 +23,15 @@
+ #define __DO_SET_H
+ 
+ #include "sequence.h"
++#include "walk_tree.h"
+ 
+ struct do_set_args {
+ 	seq_t seq;
+ 	mode_t mode;
+ };
+ 
+-extern int do_set(const char *path_p, const struct stat *stat_p, int flags,
+-		  void *arg);
++extern int do_set(int dirfd, const char *dirname, const char *pathname,
++		  unsigned char dirtype, enum walk_flags flags, void *arg);
+ 
+ /* We need these exported to us. */
+ extern const char *progname;
+Index: acl/tools/setfacl.c
+===================================================================
+--- acl.orig/tools/setfacl.c
++++ acl/tools/setfacl.c
+@@ -24,6 +24,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <fcntl.h>
+ #include <errno.h>
+ #include <sys/stat.h>
+ #include <dirent.h>
+@@ -33,7 +34,7 @@
+ #include "sequence.h"
+ #include "parse.h"
+ #include "do_set.h"
+-#include "old_walk_tree.h"
++#include "walk_tree.h"
+ 
+ #define POSIXLY_CORRECT_STR "POSIXLY_CORRECT"
+ 
+@@ -74,7 +75,7 @@ static const struct option long_options[
+ const char *progname;
+ static const char *cmd_line_options, *cmd_line_spec;
+ 
+-static int walk_flags = WALK_TREE_DEREFERENCE_TOPLEVEL;
++static enum walk_flags walk_flags = 0;
+ int opt_recalculate;  /* recalculate mask entry (0=default, 1=yes, -1=no) */
+ static int opt_promote;  /* promote access ACL to default ACL */
+ int opt_test;  /* do not write to the file system.
+@@ -184,7 +185,7 @@ restore(
+ 		}
+ 
+ 		args.mode = 0;
+-		error = do_set(path_p, &st, 0, &args);
++		error = do_set(AT_FDCWD, "", path_p, DT_UNKNOWN, WALK_TREE_PHYSICAL, &args);
+ 		if (error != 0) {
+ 			status = 1;
+ 			goto resume;
+@@ -310,14 +311,14 @@ static int next_file(const char *arg, se
+ 
+ 	if (strcmp(arg, "-") == 0) {
+ 		while ((line = __acl_next_line(stdin)))
+-			errors = old_walk_tree(line, walk_flags, 0, do_set, &args);
++			errors = walk_tree(line, walk_flags, do_set, &args);
+ 		if (!feof(stdin)) {
+ 			fprintf(stderr, _("%s: Standard input: %s\n"),
+ 				progname, strerror(errno));
+ 			errors = 1;
+ 		}
+ 	} else {
+-		errors = old_walk_tree(arg, walk_flags, 0, do_set, &args);
++		errors = walk_tree(arg, walk_flags, do_set, &args);
+ 	}
+ 	return errors ? 1 : 0;
+ }
+@@ -590,14 +591,13 @@ int main(int argc, char *argv[])
+ 				break;
+ 
+ 			case 'L':  /* follow symlinks */
+-				walk_flags |= WALK_TREE_LOGICAL | WALK_TREE_DEREFERENCE;
++				walk_flags |= WALK_TREE_LOGICAL;
+ 				walk_flags &= ~WALK_TREE_PHYSICAL;
+ 				break;
+ 
+ 			case 'P':  /* do not follow symlinks */
+ 				walk_flags |= WALK_TREE_PHYSICAL;
+-				walk_flags &= ~(WALK_TREE_LOGICAL | WALK_TREE_DEREFERENCE |
+-						WALK_TREE_DEREFERENCE_TOPLEVEL);
++				walk_flags &= ~WALK_TREE_LOGICAL;
+ 				break;
+ 
+ 			case 't':  /* test mode */
+@@ -614,7 +614,7 @@ int main(int argc, char *argv[])
+ 				status = 0;
+ 				goto cleanup;
+ 
+-			case ':':  /* option missing */
++			case ':':  /* argument missing */
+ 			case '?':  /* unknown option */
+ 			default:
+ 				goto synopsis;

--- a/debian/patches/backport-0011-CVE-2026-54370.patch
+++ b/debian/patches/backport-0011-CVE-2026-54370.patch
@@ -1,0 +1,80 @@
+From 7244f425227a23533f0b0b41c717dbd59736b907 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Sat, 20 Jun 2026 16:17:02 +0200
+Subject: [PATCH] Add openat2 syscall wrapper
+
+Add a syscall wrapper for the openat2() syscall added in kernel version v5.6
+from March 2020.
+
+On systems where the openat2() syscall is available but shouldn't be used, use
+the --disable-openat2 configure option.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ configure.ac          | 14 ++++++++++++++
+ include/Makemodule.am |  1 +
+ include/openat2.h     | 16 ++++++++++++++++
+ libmisc/Makemodule.am |  7 +++++++
+ libmisc/openat2.c     | 30 ++++++++++++++++++++++++++++++
+ 5 files changed, 68 insertions(+)
+ create mode 100644 include/openat2.h
+ create mode 100644 libmisc/openat2.c
+
+Index: acl/configure.ac
+===================================================================
+--- acl.orig/configure.ac
++++ acl/configure.ac
+@@ -34,6 +34,20 @@ AC_SYS_LARGEFILE
+ AM_PROG_AR
+ LT_INIT
+ 
++AC_CHECK_FUNCS(openat2)
++AC_CHECK_HEADERS([linux/openat2.h])
++AC_CHECK_DECL([__NR_openat2], [], [], [[#include <sys/syscall.h>]])
++if test "x$ac_cv_have_decl___NR_openat2" = xyes -a \
++	"x$ac_cv_header_linux_openat2_h" = xyes; then
++	use_openat2=yes
++else
++	use_openat2=no
++fi
++AM_CONDITIONAL([USE_OPENAT2], [test "x$use_openat2" = xyes])
++AM_CONDITIONAL([HAVE_OPENAT2], [test "x$ac_cv_func_openat2" = xyes])
++AS_IF([test "x$use_openat2" = xyes],
++      [AC_DEFINE([USE_OPENAT2], [1], [Define to use openat2 syscall])])
++
+ AC_CHECK_FUNCS(getxattrat setxattrat listxattrat removexattrat)
+ AM_CONDITIONAL([NEED_XATTRAT],
+ 	       [test "x$ac_cv_func_getxattrat" = xno -o \
+Index: acl/include/Makemodule.am
+===================================================================
+--- acl.orig/include/Makemodule.am
++++ acl/include/Makemodule.am
+@@ -5,6 +5,7 @@ noinst_HEADERS += \
+ 	include/fchmodat_compat.h \
+ 	include/misc.h \
+ 	include/old_walk_tree.h \
++	include/openat2.h \
+ 	include/visibility-hidden.h \
+ 	include/walk_tree.h \
+ 	include/xattrat.h \
+Index: acl/include/openat2.h
+===================================================================
+--- /dev/null
++++ acl/include/openat2.h
+@@ -0,0 +1,16 @@
++#ifndef MISC_OPENAT2_H
++#define MISC_OPENAT2_H
++
++#include "config.h"
++#include <stdint.h>
++
++#ifdef USE_OPENAT2
++#include <linux/openat2.h>
++
++#ifndef HAVE_OPENAT2
++int openat2(int dirfd, const char *pathname, const struct open_how *how,
++	    size_t size);
++#endif
++#endif
++
++#endif /* MISC_OPENAT2_H */

--- a/debian/patches/backport-0012-CVE-2026-54370.patch
+++ b/debian/patches/backport-0012-CVE-2026-54370.patch
@@ -1,0 +1,52 @@
+From c4ba4a97f7858d82c177ebadfea0b79464c86bff Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Mon, 22 Jun 2026 01:08:57 +0200
+Subject: [PATCH] Add restore.run test
+
+Add a new restore.run test script and move the existing --restore test from
+misc.run there.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ test/Makemodule.am | 1 +
+ test/misc.run      | 6 ------
+ test/restore.run   | 5 +++++
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+ create mode 100644 test/restore.run
+
+Index: acl/test/Makemodule.am
+===================================================================
+--- acl.orig/test/Makemodule.am
++++ acl/test/Makemodule.am
+@@ -10,6 +10,7 @@ TESTS = \
+ 	test/getfacl-recursive.run \
+ 	test/malformed-restore.run \
+ 	test/misc.run \
++	test/restore.run \
+ 	test/sbits-restore.run \
+ 	test/setfacl-X.run \
+ 	test/utf8-filenames.run \
+Index: acl/test/misc.run
+===================================================================
+--- acl.orig/test/misc.run
++++ acl/test/misc.run
+@@ -493,9 +493,3 @@ Handle escaped literal characters by oct
+ 	> other::r--
+ 	> 
+ 	$ rm -R d
+-
+-Malformed restore file
+-
+-	$ echo "# owner: root" > f
+-	$ setfacl --restore=f 2>&1
+-	>setfacl: f: No filename found in line 0, aborting
+Index: acl/test/restore.run
+===================================================================
+--- /dev/null
++++ acl/test/restore.run
+@@ -0,0 +1,5 @@
++Malformed restore file
++
++	$ echo "# owner: root" > dump
++	$ setfacl --restore=dump 2>&1
++	>setfacl: dump: No filename found in line 0, aborting

--- a/debian/patches/backport-0013-CVE-2026-54370.patch
+++ b/debian/patches/backport-0013-CVE-2026-54370.patch
@@ -1,0 +1,538 @@
+From 54e14e9bc545f505b379d0792a2748d9baf88700 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Sat, 20 Jun 2026 19:35:48 +0200
+Subject: [PATCH] harden setfacl --restore
+
+In setfacl --restore, use functions that support the AT_SYMLINK_NOFOLLOW flag
+(stat() -> fstatat(), chown() -> fchownat(), chmod() -> fchmodat()).  Allow the
+-P (--physical) option to be used together with --restore.
+
+In physical restore mode, use openat2(RESOLVE_NO_SYMLINKS) for resolving the
+pathname components leading up to the last one, and use the AT_SYMLINK_NOFOLLOW
+flag on the last pathname component.
+
+On systems where openat2() *is* available, warn when attempting a non-physical
+restore as that can be dangerous.  The purpose of this warning is to cause
+users to switch to physical restore mode over time.
+
+This warning can be disabled with the --disable-unsafe-restore-warnings
+configure option.
+
+On systems where openat2() *is not* available, do not warn when attempting a
+non-physical restore; this is to preserve the historic behavior when building
+this package on older systems.  On those systems, a physical restore will fail
+with ENOSYS ("Function not implemented").
+
+Fixes: CVE-2026-54370 ("acl < 2.4.0 TOCTOU Symlink Traversal via getfacl/setfacl")
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ configure.ac            |   9 ++
+ man/man1/setfacl.1      |  16 +--
+ test/Makemodule.am      |  10 +-
+ test/restore.run        |  21 ++++
+ test/root/restore.run   |   2 +-
+ test/sbits-restore.run  |   2 +-
+ test/utf8-filenames.run |   2 +-
+ tools/setfacl.c         | 211 +++++++++++++++++++++++++++++++++-------
+ 8 files changed, 226 insertions(+), 47 deletions(-)
+
+Index: acl/configure.ac
+===================================================================
+--- acl.orig/configure.ac
++++ acl/configure.ac
+@@ -48,6 +48,15 @@ AM_CONDITIONAL([HAVE_OPENAT2], [test "x$
+ AS_IF([test "x$use_openat2" = xyes],
+       [AC_DEFINE([USE_OPENAT2], [1], [Define to use openat2 syscall])])
+ 
++AC_ARG_ENABLE([unsafe-restore-warnings],
++	[AS_HELP_STRING([--disable-unsafe-restore-warnings], [Disable warnings about unsafe restore operations])])
++if test "x$use_openat2" = xno; then
++	enable_unsafe_restore_warnings=no
++fi
++AM_CONDITIONAL([UNSAFE_RESTORE_WARNINGS], [test "x$enable_unsafe_restore_warnings" != xno])
++AS_IF([test "x$enable_unsafe_restore_warnings" != xno],
++      [AC_DEFINE([UNSAFE_RESTORE_WARNINGS], [1], [Define to enable unsafe restore warnings])])
++
+ AC_CHECK_FUNCS(getxattrat setxattrat listxattrat removexattrat)
+ AM_CONDITIONAL([NEED_XATTRAT],
+ 	       [test "x$ac_cv_func_getxattrat" = xno -o \
+Index: acl/test/Makemodule.am
+===================================================================
+--- acl.orig/test/Makemodule.am
++++ acl/test/Makemodule.am
+@@ -10,16 +10,20 @@ TESTS = \
+ 	test/getfacl-recursive.run \
+ 	test/malformed-restore.run \
+ 	test/misc.run \
+-	test/restore.run \
+-	test/sbits-restore.run \
+ 	test/setfacl-X.run \
+-	test/utf8-filenames.run \
+ 	test/root/getfacl.run \
+ 	test/root/permissions.run \
+ 	test/root/restore.run \
+ 	test/root/setfacl.run \
+ 	$(XFAIL_TESTS)
+ 
++if UNSAFE_RESTORE_WARNINGS
++TESTS += \
++	test/restore.run \
++	test/sbits-restore.run \
++	test/utf8-filenames.run
++endif
++
+ EXTRA_DIST += \
+ 	test/make-tree \
+ 	test/malformed-restore-double-owner.acl \
+Index: acl/test/restore.run
+===================================================================
+--- acl.orig/test/restore.run
++++ acl/test/restore.run
+@@ -1,3 +1,24 @@
++        $ mkdir d
++        $ touch d/f
++        $ ln -s f d/l
++        $ getfacl -RP d > physical
++        $ getfacl -RL d > logical
++
++Restoring a physical backup should work:
++
++        $ setfacl --restore=physical --physical
++
++Restoring a backup non-physically should produce the following warning:
++
++        $ setfacl --restore=physical
++	> Warning: option --restore=file is unsafe without option -P (--physical) as it traverses symbolic links in pathnames
++
++
++Restoring a logical backup can fail:
++
++        $ setfacl --restore=logical --physical
++        > setfacl: d/l: Too many levels of symbolic links
++
+ Malformed restore file
+ 
+ 	$ echo "# owner: root" > dump
+Index: acl/test/root/restore.run
+===================================================================
+--- acl.orig/test/root/restore.run
++++ acl/test/root/restore.run
+@@ -20,7 +20,7 @@ Cry immediately if we are not running as
+ 	>
+ 	$ chown bin passwd
+ 	$ chmod u+s passwd
+-	$ setfacl --restore passwd.acl
++	$ setfacl --restore passwd.acl --physical
+ 	$ ls -dl passwd | awk '{print $1 " " $3 " " $4}' | sed 's/\\.//g'
+ 	> -rwsr-xr-x root root
+ 
+Index: acl/test/sbits-restore.run
+===================================================================
+--- acl.orig/test/sbits-restore.run
++++ acl/test/sbits-restore.run
+@@ -12,7 +12,7 @@ Ensure setting of SUID/SGID/sticky via -
+ 	$ mkdir d
+ 	$ touch d/g
+ 	$ touch d/u
+-	$ setfacl --restore d.acl
++	$ setfacl --restore=d.acl --physical
+ 	$ ls -dl d | awk '{print $1}' | sed 's/\\.$//g'
+ 	> drwxr-xr-t
+ 	$ ls -dl d/u | awk '{print $1}' | sed 's/\\.$//g'
+Index: acl/test/utf8-filenames.run
+===================================================================
+--- acl.orig/test/utf8-filenames.run
++++ acl/test/utf8-filenames.run
+@@ -9,6 +9,6 @@ NAME_MAX.
+        $ mkdir -p $UPATH/$UPATH/$UPATH
+        $ touch $UPATH/$UPATH/$UPATH/$UPATH
+        $ getfacl $UPATH/$UPATH/$UPATH/$UPATH > utf8-filenames.acl
+-       $ setfacl  --restore=utf8-filenames.acl
++       $ setfacl  --restore=utf8-filenames.acl --physical
+        $ rm -R $UPATH
+        $ rm utf8-filenames.acl
+Index: acl/tools/setfacl.c
+===================================================================
+--- acl.orig/tools/setfacl.c
++++ acl/tools/setfacl.c
+@@ -35,16 +35,19 @@
+ #include "parse.h"
+ #include "do_set.h"
+ #include "walk_tree.h"
++#include "openat2.h"
++#include "fchmodat_compat.h"
+ 
+ #define POSIXLY_CORRECT_STR "POSIXLY_CORRECT"
+ 
+ /* '-' stands for `process non-option arguments in loop' */
+ #if !POSIXLY_CORRECT
+ #  define CMD_LINE_OPTIONS "-:bkndvhm:M:x:X:RLP"
+-#  define CMD_LINE_SPEC "[-bkndRLP] { -m|-M|-x|-X ... } file ..."
++#  define CMD_LINE_SPEC1 "[-bkndRLP] { -m|-M|-x|-X ... } file ..."
++#  define CMD_LINE_SPEC2 "[-P] --restore=file"
+ #endif
+ #define POSIXLY_CMD_LINE_OPTIONS "-:bkndvhm:M:x:X:"
+-#define POSIXLY_CMD_LINE_SPEC "[-bknd] {-m|-M|-x|-X ... } file ..."
++#define POSIXLY_CMD_LINE_SPEC1 "[-bknd] {-m|-M|-x|-X ... } file ..."
+ 
+ static const struct option long_options[] = {
+ #if !POSIXLY_CORRECT
+@@ -117,7 +120,8 @@ has_any_of_type(
+ static int
+ restore(
+ 	FILE *file,
+-	const char *filename)
++	const char *filename,
++	enum walk_flags walk_flags)
+ {
+ 	char *path_p;
+ 	struct stat st;
+@@ -128,6 +132,12 @@ restore(
+ 	int lineno = 0, backup_line;
+ 	int error, status = 0;
+ 	int chmod_required = 0;
++	int dirfd = -1;
++	char *dirname = NULL, *pathname;
++	int at_flags = (walk_flags & WALK_TREE_PHYSICAL) ? AT_SYMLINK_NOFOLLOW : 0;
++#ifdef UNSAFE_RESTORE_WARNINGS
++	static int non_physical_restore_warning;
++#endif
+ 
+ 	memset(&st, 0, sizeof(st));
+ 
+@@ -177,15 +187,75 @@ restore(
+ 			goto getout;
+ 		}
+ 
+-		error = stat(path_p, &st);
+-		if (opt_test && error != 0) {
++#ifdef UNSAFE_RESTORE_WARNINGS
++		if (!(walk_flags & WALK_TREE_PHYSICAL) &&
++		    !non_physical_restore_warning) {
++			fprintf(stderr,
++				_("Warning: option --restore=file is unsafe "
++				  "without option -P (--physical) as it "
++				  "traverses symbolic links in pathnames\n"));
++			non_physical_restore_warning = 1;
++		}
++#endif
++
++		/* find the last pathname component */
++		pathname = path_p + strlen(path_p);
++		while (pathname > path_p && pathname[-1] == '/')
++			pathname--;
++		while (pathname > path_p && pathname[-1] != '/')
++			pathname--;
++
++		if ((walk_flags & WALK_TREE_PHYSICAL) && pathname != path_p) {
++			dirname = malloc(pathname - path_p + 1);
++			if (dirname == NULL) {
++				fprintf(stderr, "%s: %s\n",
++					progname, strerror(errno));
++				status = 1;
++				goto getout;
++			}
++			memcpy(dirname, path_p, pathname - path_p);
++			dirname[pathname - path_p] = '\0';
++#ifdef USE_OPENAT2
++			struct open_how how = {
++				.flags = O_PATH | O_DIRECTORY,
++				.resolve = RESOLVE_NO_SYMLINKS,
++			};
++			dirfd = openat2(AT_FDCWD, dirname, &how, sizeof(how));
++#else
++			errno = ENOSYS;
++			dirfd = -1;
++#endif
++			if (dirfd == -1) {
++				fprintf(stderr,
++					_("%s: lookup of directory %s without "
++					  "following symlinks: %s\n"),
++					progname,
++					xquote(dirname, "\n\r"),
++					strerror(errno));
++				status = 1;
++				goto resume;
++			}
++		} else {
++			dirfd = AT_FDCWD;
++			dirname = "";
++			pathname = path_p;
++		}
++
++		error = fstatat(dirfd, pathname, &st, at_flags);
++		if (error == 0 && S_ISLNK(st.st_mode)) {
++			errno = ELOOP;
++			error = -1;
++		}
++		if (error != 0) {
+ 			fprintf(stderr, "%s: %s: %s\n", progname,
+ 				xquote(path_p, "\n\r"), strerror(errno));
+ 			status = 1;
++			goto resume;
+ 		}
+ 
+ 		args.mode = 0;
+-		error = do_set(AT_FDCWD, "", path_p, DT_UNKNOWN, WALK_TREE_PHYSICAL, &args);
++		error = do_set(dirfd, dirname, pathname, DT_UNKNOWN,
++			       walk_flags | WALK_TREE_TOPLEVEL, &args);
+ 		if (error != 0) {
+ 			status = 1;
+ 			goto resume;
+@@ -201,7 +271,8 @@ restore(
+ 			st.st_gid = -1;
+ 		if (!opt_test &&
+ 		    (st.st_uid != -1 || st.st_gid != -1)) {
+-			if (chown(path_p, st.st_uid, st.st_gid) != 0) {
++			if (fchownat(dirfd, pathname, st.st_uid, st.st_gid,
++				     at_flags) != 0) {
+ 				fprintf(stderr, _("%s: %s: Cannot change "
+ 					          "owner/group: %s\n"),
+ 					progname, xquote(path_p, "\n\r"),
+@@ -220,7 +291,8 @@ restore(
+ 			if (!args.mode)
+ 				args.mode = st.st_mode;
+ 			args.mode &= (S_IRWXU | S_IRWXG | S_IRWXO);
+-			if (chmod(path_p, flags | args.mode) != 0) {
++			if (fchmodat(dirfd, pathname, flags | args.mode,
++				     at_flags) != 0) {
+ 				fprintf(stderr, _("%s: %s: Cannot change "
+ 					          "mode: %s\n"),
+ 					progname, xquote(path_p, "\n\r"),
+@@ -229,6 +301,14 @@ restore(
+ 			}
+ 		}
+ resume:
++		if (dirfd != -1 && dirfd != AT_FDCWD) {
++			close(dirfd);
++			dirfd = -1;
++		}
++		if (dirname && *dirname) {
++			free(dirname);
++			dirname = NULL;
++		}
+ 		if (path_p) {
+ 			free(path_p);
+ 			path_p = NULL;
+@@ -267,6 +347,12 @@ static void help(void)
+ 		progname, VERSION);
+ 	printf(_("Usage: %s %s\n"),
+ 		progname, cmd_line_spec);
++#if !POSIXLY_CORRECT
++	if (!posixly_correct) {
++		printf("       %s %s\n",
++		      progname, CMD_LINE_SPEC2);
++	}
++#endif
+ 	printf(_(
+ "  -m, --modify=acl        modify the current ACL(s) of file(s)\n"
+ "  -M, --modify-file=file  read ACL entries to modify from file\n"
+@@ -330,6 +416,9 @@ static int next_file(const char *arg, se
+ 
+ int main(int argc, char *argv[])
+ {
++	enum { UNDEFINED_MODE, SET_MODE, RESTORE_MODE } mode = UNDEFINED_MODE;
++	char **restore_args = NULL;
++	int opt_restore_count = 0;
+ 	int opt;
+ 	int saw_files = 0;
+ 	int status = 0, status2;
+@@ -344,16 +433,16 @@ int main(int argc, char *argv[])
+ 
+ #if POSIXLY_CORRECT
+ 	cmd_line_options = POSIXLY_CMD_LINE_OPTIONS;
+-	cmd_line_spec = _(POSIXLY_CMD_LINE_SPEC);
++	cmd_line_spec = POSIXLY_CMD_LINE_SPEC1;
+ #else
+ 	if (getenv(POSIXLY_CORRECT_STR))
+ 		posixly_correct = 1;
+ 	if (!posixly_correct) {
+ 		cmd_line_options = CMD_LINE_OPTIONS;
+-		cmd_line_spec = _(CMD_LINE_SPEC);
++		cmd_line_spec = CMD_LINE_SPEC1;
+ 	} else {
+ 		cmd_line_options = POSIXLY_CMD_LINE_OPTIONS;
+-		cmd_line_spec = _(POSIXLY_CMD_LINE_SPEC);
++		cmd_line_spec = POSIXLY_CMD_LINE_SPEC1;
+ 	}
+ #endif
+ 
+@@ -383,6 +472,9 @@ int main(int argc, char *argv[])
+ 
+ 		switch (opt) {
+ 			case 'b':  /* remove all extended entries */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				if (seq_append_cmd(seq, CMD_REMOVE_EXTENDED_ACL,
+ 				                        ACL_TYPE_ACCESS) ||
+ 				    seq_append_cmd(seq, CMD_REMOVE_ACL,
+@@ -391,20 +483,32 @@ int main(int argc, char *argv[])
+ 				break;
+ 
+ 			case 'k':  /* remove default ACL */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				if (seq_append_cmd(seq, CMD_REMOVE_ACL,
+ 				                        ACL_TYPE_DEFAULT))
+ 					ERRNO_ERROR(1);
+ 				break;
+ 
+ 			case 'n':  /* do not recalculate mask */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				opt_recalculate = -1;
+ 				break;
+ 
+ 			case 'r':  /* force recalculate mask */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				opt_recalculate = 1;
+ 				break;
+ 
+ 			case 'd':  /*  operations apply to default ACL */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				opt_promote = 1;
+ 				break;
+ 
+@@ -440,6 +544,9 @@ int main(int argc, char *argv[])
+ 				goto set_modify_delete;
+ 
+ 			set_modify_delete:
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				if (!posixly_correct)
+ 					parse_mode |= SEQ_PARSE_DEFAULT;
+ 				if (opt_promote)
+@@ -498,6 +605,9 @@ int main(int argc, char *argv[])
+ 				goto set_modify_delete_from_file;
+ 
+ 			set_modify_delete_from_file:
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				if (!posixly_correct)
+ 					parse_mode |= SEQ_PARSE_DEFAULT;
+ 				if (opt_promote)
+@@ -551,6 +661,9 @@ int main(int argc, char *argv[])
+ 
+ 
+ 			case '\1':  /* file argument */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				if (seq_empty(seq))
+ 					goto synopsis;
+ 				saw_files = 1;
+@@ -561,36 +674,31 @@ int main(int argc, char *argv[])
+ 				break;
+ 
+ 			case 'B':  /* restore ACL backup */
+-				saw_files = 1;
+-
+-				if (strcmp(optarg, "-") == 0)
+-					file = stdin;
+-				else {
+-					file = fopen(optarg, "r");
+-					if (file == NULL) {
+-						fprintf(stderr, "%s: %s: %s\n",
+-							progname,
+-							xquote(optarg, "\n\r"),
+-							strerror(errno));
+-						status = 2;
+-						goto cleanup;
+-					}
+-				}
+-
+-				status = restore(file,
+-				               (file == stdin) ? NULL : optarg);
+-
+-				if (file != stdin)
+-					fclose(file);
+-				if (status != 0)
++				if (mode == SET_MODE)
++					goto synopsis;
++				mode = RESTORE_MODE;
++				opt_restore_count++;
++				restore_args = realloc(restore_args,
++					opt_restore_count * sizeof(*restore_args));
++				if (!restore_args) {
++					fprintf(stderr, "%s: %s\n", progname, strerror(errno));
++					status = 1;
+ 					goto cleanup;
++				}
++				restore_args[opt_restore_count - 1] = optarg;
+ 				break;
+ 
+ 			case 'R':  /* recursive */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				walk_flags |= WALK_TREE_RECURSIVE;
+ 				break;
+ 
+ 			case 'L':  /* follow symlinks */
++				if (mode == RESTORE_MODE)
++					goto synopsis;
++				mode = SET_MODE;
+ 				walk_flags |= WALK_TREE_LOGICAL;
+ 				walk_flags &= ~WALK_TREE_PHYSICAL;
+ 				break;
+@@ -636,7 +744,42 @@ int main(int argc, char *argv[])
+ 				seq_delete_cmd(seq, seq_remove_default_acl_cmd);
+ 		}
+ 	}
++
++	if (mode == RESTORE_MODE) {
++		if (walk_flags & WALK_TREE_LOGICAL)
++			goto synopsis;
++
++		for (opt = 0; opt < opt_restore_count; opt++) {
++			if (strcmp(restore_args[opt], "-") == 0)
++				file = stdin;
++			else {
++				file = fopen(restore_args[opt], "r");
++				if (file == NULL) {
++					fprintf(stderr, "%s: %s: %s\n",
++						progname,
++						xquote(restore_args[opt], "\n\r"),
++						strerror(errno));
++					status = 2;
++					goto cleanup;
++				}
++			}
++
++			status2 = restore(file,
++			               (file == stdin) ? NULL : restore_args[opt],
++			               walk_flags);
++
++			if (file != stdin)
++				fclose(file);
++			if (status == 0)
++				status = status2;
++		}
++		free(restore_args);
++	}
++
+ 	while (optind < argc) {
++		if (mode == RESTORE_MODE)
++			goto synopsis;
++		mode = SET_MODE;
+ 		if(!seq)
+ 			goto synopsis;
+ 		if (seq_empty(seq))
+@@ -647,7 +790,7 @@ int main(int argc, char *argv[])
+ 		if (status == 0)
+ 			status = status2;
+ 	}
+-	if (!saw_files)
++	if (mode == SET_MODE && !saw_files)
+ 		goto synopsis;
+ 
+ 	goto cleanup;

--- a/debian/patches/backport-0014-CVE-2026-54370.patch
+++ b/debian/patches/backport-0014-CVE-2026-54370.patch
@@ -1,0 +1,76 @@
+From 601cc884a548ae9e9d246ae749e54b3272e4b1d7 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Mon, 8 Jun 2026 13:47:24 +0200
+Subject: [PATCH] harden chacl
+
+Harden chacl by making sure it doesn't follow any symbolic links other than
+the ones specified on the command line.  This is done by resolving pathnames
+relative to directory file descriptors and switching to symlink-safe functions
+(acl_get_file() -> acl_get_file_at(), acl_set_file() -> acl_set_file_at(),
+opendir() -> openat() + fdopendir()).
+
+Fixes: CVE-2026-54370 ("acl < 2.4.0 TOCTOU Symlink Traversal via getfacl/setfacl")
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ tools/chacl.c | 108 +++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 77 insertions(+), 31 deletions(-)
+
+Index: acl/tools/chacl.c
+===================================================================
+--- acl.orig/tools/chacl.c
++++ acl/tools/chacl.c
+@@ -21,6 +21,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <fcntl.h>
+ #include <getopt.h>
+ #include <libgen.h>
+ #include <stdio.h>
+@@ -34,8 +35,10 @@
+ 
+ static int acl_delete_file (const char * path, acl_type_t type);
+ static int list_acl(char *file);
+-static int set_acl(acl_t acl, acl_t dacl, const char *fname);
+-static int walk_dir(acl_t acl, acl_t dacl, const char *fname);
++static int set_acl(acl_t acl, acl_t dacl, int dirfd, const char *dname,
++		   const char *fname, unsigned int depth);
++static int walk_dir(acl_t acl, acl_t dacl, int dirfd, const char *dname,
++		    const char *fname, unsigned int depth);
+ 
+ static char *program;
+ static int rflag;
+@@ -197,7 +200,7 @@ main(int argc, char *argv[])
+ 
+ 	/* place acls on files */
+ 	for (; optind < argc; optind++)
+-		failed += set_acl(acl, dacl, argv[optind]);
++		failed += set_acl(acl, dacl, AT_FDCWD, "", argv[optind], 0);
+ 
+ 	if (acl)
+ 		acl_free(acl);
+@@ -221,7 +224,8 @@ acl_delete_file(const char *path, acl_ty
+ 		acl_entry_t entry;
+ 		acl_tag_t tag;
+ 
+-		acl = acl_get_file(path, ACL_TYPE_ACCESS);
++		acl = acl_get_file_at(AT_FDCWD, path, AT_SYMLINK_NOFOLLOW,
++				      ACL_TYPE_ACCESS);
+ 		if (!acl)
+ 			return -1;
+ 		error = acl_get_entry(acl, ACL_FIRST_ENTRY, &entry);
+@@ -237,9 +241,12 @@ acl_delete_file(const char *path, acl_ty
+ 			error = acl_get_entry(acl, ACL_NEXT_ENTRY, &entry);
+ 		}
+ 		if (!error)
+-			error = acl_set_file(path, ACL_TYPE_ACCESS, acl);
++			error = acl_set_file_at(AT_FDCWD, path,
++						AT_SYMLINK_NOFOLLOW,
++						ACL_TYPE_ACCESS, acl);
+ 	} else
+-		error = acl_delete_def_file(path);
++		error = acl_delete_def_file_at(AT_FDCWD, path,
++					       AT_SYMLINK_NOFOLLOW);
+ 	return(error);
+ }
+ 

--- a/debian/patches/backport-Fix-some-compiler-warnings-for-CVE-2026-54369-CVE-2026-54370.patch
+++ b/debian/patches/backport-Fix-some-compiler-warnings-for-CVE-2026-54369-CVE-2026-54370.patch
@@ -1,0 +1,29 @@
+From a009adf38ed8cf3cc2ad8bfb7060630caba0bdaa Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruenba@redhat.com>
+Date: Sat, 20 Jun 2026 02:12:14 +0200
+Subject: [PATCH] Fix some compiler warnings
+
+Enable -Wall, -Wextra, and -Wmissing-prototypes and fix the resulting compiler
+warnings.
+
+Signed-off-by: Andreas Gruenbacher <agruenba@redhat.com>
+---
+ libmisc/xattrat.c         | 5 +++++
+ 1 files changed, 5 insertions(+), 0 deletions(-)
+
+Index: acl/libmisc/xattrat.c
+===================================================================
+--- acl.orig/libmisc/xattrat.c
++++ acl/libmisc/xattrat.c
+@@ -21,6 +21,11 @@
+ #include <linux/xattr.h>
+ #include <sys/syscall.h>
+ #include <unistd.h>
++#include <errno.h>
++
++#include "xattrat.h"
++
++#pragma GCC diagnostic ignored "-Wunused-parameter"
+ 
+ #include "xattrat.h"
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,29 @@
 0001-libmisc-__acl_get_uid-fix-memory-wasting-loop-if-use.patch
 # Local patches
 getfacl-fix-uninitialized-variable.patch
+# CVE-2026-54369 patches
+backport-0001-CVE-2026-54369.patch
+backport-0002-CVE-2026-54369.patch
+backport-0003-CVE-2026-54369.patch
+backport-0004-CVE-2026-54369.patch
+backport-0005-CVE-2026-54369.patch
+backport-0006-CVE-2026-54369.patch
+backport-0007-CVE-2026-54369.patch
+backport-0008-CVE-2026-54369.patch
+# CVE-2026-54370 patches
+backport-0001-CVE-2026-54370.patch
+backport-0002-CVE-2026-54370.patch
+backport-0003-CVE-2026-54370.patch
+backport-0004-CVE-2026-54370.patch
+backport-0005-CVE-2026-54370.patch
+backport-0006-CVE-2026-54370.patch
+backport-0007-CVE-2026-54370.patch
+backport-0008-CVE-2026-54370.patch
+backport-0009-CVE-2026-54370.patch
+backport-0010-CVE-2026-54370.patch
+backport-0011-CVE-2026-54370.patch
+backport-0012-CVE-2026-54370.patch
+backport-0013-CVE-2026-54370.patch
+backport-0014-CVE-2026-54370.patch
+# Fix compiler warnings for CVE-2026-54369 and CVE-2026-54370
+backport-Fix-some-compiler-warnings-for-CVE-2026-54369-CVE-2026-54370.patch

--- a/libmisc/Makemodule.am
+++ b/libmisc/Makemodule.am
@@ -4,6 +4,12 @@ libmisc_la_SOURCES = \
 	libmisc/uid_gid_lookup.c \
 	libmisc/high_water_alloc.c \
 	libmisc/next_line.c \
+	libmisc/fchmodat_compat.c \
 	libmisc/quote.c \
 	libmisc/unquote.c \
 	libmisc/walk_tree.c
+
+if NEED_XATTRAT
+libmisc_la_SOURCES += \
+	libmisc/xattrat.c
+endif


### PR DESCRIPTION
- CVE-2026-54369: Symlink traversal in libacl pathname-based functions
- CVE-2026-54370: TOCTOU race condition in getfacl, setfacl, chacl

Add walk_tree helper using directory file descriptors, openat2 syscall wrapper, xattrat/fchmodat syscall backwards compatibility code, and libacl _at function variants. Harden getfacl, setfacl, chacl with AT_SYMLINK_NOFOLLOW and openat2(RESOLVE_NO_SYMLINKS). Fix setfacl --restore path handling.

Also fix compiler warnings for CVE-2026-54369 and CVE-2026-54370.

Upstream: https://git.savannah.nongnu.org/git/acl.git

Log: backport CVE fixes from upstream
Influence: libacl, getfacl, setfacl, chacl - security hardening